### PR TITLE
Terminal-like UX: vim modal input, breadcrumb fixes, RTL tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,20 +26,34 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/jsdom": "^28.0.1",
         "@types/node": "^22.5.4",
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^4.3.4",
         "bun-types": "^1.3.11",
+        "happy-dom": "^20.8.9",
+        "jsdom": "^29.0.1",
         "typescript": "^5.8.0",
         "vite": "^6.3.0",
       },
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
     "@anthropic-ai/claude-agent-sdk": ["@anthropic-ai/claude-agent-sdk@0.2.92", "", { "dependencies": { "@anthropic-ai/sdk": "^0.80.0", "@modelcontextprotocol/sdk": "^1.27.1" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "^0.34.2", "@img/sharp-darwin-x64": "^0.34.2", "@img/sharp-linux-arm": "^0.34.2", "@img/sharp-linux-arm64": "^0.34.2", "@img/sharp-linux-x64": "^0.34.2", "@img/sharp-linuxmusl-arm64": "^0.34.2", "@img/sharp-linuxmusl-x64": "^0.34.2", "@img/sharp-win32-arm64": "^0.34.2", "@img/sharp-win32-x64": "^0.34.2" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-loYyxVUC5gBwHjGi9Fv0b84mduJTp9Z3Pum+y/7IVQDb4NynKfVQl6l4VeDKZaW+1QTQtd25tY4hwUznD7Krqw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.80.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.5", "", { "dependencies": { "@csstools/css-calc": "^3.1.1", "@csstools/css-color-parser": "^4.0.2", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.2.7" } }, "sha512-8cMAA1bE66Mb/tfmkhcfJLjEPgyT7SSy6lW6id5XL113ai1ky76d/1L27sGnXCMsLfq66DInAU3OzuahB4lu9Q=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.0.6", "", { "dependencies": { "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7" } }, "sha512-Tgmk6EQM0nc9xvp7sEHRVavbknhb/vGKht+04yAT3t5KQwZ02CSobCtcFgaHH04ZrjD1BhEKNA8tRhzFV20gkA=="],
+
+    "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
@@ -121,6 +135,20 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.1.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.0.2", "", { "dependencies": { "@csstools/color-helpers": "^6.0.2", "@csstools/css-calc": "^3.1.1" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.2", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
+
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.59.1", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-Qg+meC+XFxliuVSDlEPkKnaUjdaJKK6FNx/Wwl2UxhQR8pyPIuLhMavsF7ePdB9qFZUWV1jEK3ckbJir/WmF4w=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.6", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-patgsRPKGkhhoBjETV4XxD0En4ui5fbX0hzayqI3M8tvNMGUoUvmyYAIWwlxBc1KX5cturfqByYdj5bYGRpN9g=="],
@@ -176,6 +204,8 @@
     "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
@@ -513,7 +543,17 @@
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -531,6 +571,8 @@
 
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
+    "@types/jsdom": ["@types/jsdom@28.0.1", "", { "dependencies": { "@types/node": "*", "@types/tough-cookie": "*", "parse5": "^7.0.0", "undici-types": "^7.21.0" } }, "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw=="],
+
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
@@ -543,9 +585,15 @@
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
@@ -561,9 +609,9 @@
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
-    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
 
@@ -572,6 +620,8 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
@@ -582,6 +632,8 @@
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.14", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
@@ -669,7 +721,11 @@
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
 
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
     "css-what": ["css-what@6.2.2", "", {}, "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
@@ -677,7 +733,11 @@
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
 
@@ -702,6 +762,8 @@
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -729,7 +791,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.20.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -827,6 +889,8 @@
 
     "h3-v2": ["h3@2.0.1-rc.16", "", { "dependencies": { "rou3": "^0.8.0", "srvx": "^0.11.9" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-h+pjvyujdo9way8qj6FUbhaQcHlR8FEq65EhTX9ViT5pK8aLj68uFl4hBkF+hsTJAH+H1END2Yv6hTIsabGfag=="],
 
+    "happy-dom": ["happy-dom@20.8.9", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA=="],
+
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
@@ -838,6 +902,8 @@
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
     "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
 
@@ -854,6 +920,8 @@
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
+
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -897,6 +965,8 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "is-regexp": ["is-regexp@3.1.0", "", {}, "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="],
@@ -918,6 +988,8 @@
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "jsdom": ["jsdom@29.0.1", "", { "dependencies": { "@asamuzakjp/css-color": "^5.0.1", "@asamuzakjp/dom-selector": "^7.0.3", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.1", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.2.7", "parse5": "^8.0.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.24.5", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -965,9 +1037,11 @@
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@11.3.0", "", {}, "sha512-sr8xPKE25m6vJVcrdn6NxtC0fVfuPowbscLypegRgOm0yXSqr5JNHCAY3hnusdJ7HRBW04j6Ip4khvHU778DuQ=="],
 
     "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -988,6 +1062,8 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
 
     "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
@@ -1048,6 +1124,8 @@
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -1131,6 +1209,8 @@
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
@@ -1138,6 +1218,8 @@
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "qs": ["qs@6.15.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ=="],
 
@@ -1153,6 +1235,8 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
@@ -1166,6 +1250,8 @@
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
+
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
 
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
@@ -1196,6 +1282,8 @@
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -1255,9 +1343,13 @@
 
     "strip-final-newline": ["strip-final-newline@4.0.0", "", {}, "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw=="],
 
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
@@ -1280,6 +1372,8 @@
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
     "tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -1307,7 +1401,7 @@
 
     "undici": ["undici@7.24.7", "", {}, "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.24.7", "", {}, "sha512-XA+gOBkzYD3C74sZowtCLTpgtaCdqZhqCvR6y9LXvrKTt/IVU6bz49T4D+BPi475scshCCkb0IklJRw6T1ZlgQ=="],
 
     "unicorn-magic": ["unicorn-magic@0.3.0", "", {}, "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA=="],
 
@@ -1353,13 +1447,19 @@
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
     "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
 
-    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
+    "whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
@@ -1367,9 +1467,15 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
     "xmlbuilder2": ["xmlbuilder2@4.0.3", "", { "dependencies": { "@oozcitak/dom": "^2.0.2", "@oozcitak/infra": "^2.0.2", "@oozcitak/util": "^10.0.0", "js-yaml": "^4.1.1" } }, "sha512-bx8Q1STctnNaaDymWnkfQLKofs0mGNN7rLLapJlGuV3VlvegD7Ls4ggMjE3aUSWItCCzU0PEv45lI87iSigiCA=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -1388,6 +1494,8 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
@@ -1409,7 +1517,15 @@
 
     "@tanstack/start-plugin-core/@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.40", "", {}, "sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w=="],
 
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
+    "@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
+    "cheerio/whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
 
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1419,11 +1535,17 @@
 
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "data-urls/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "dom-serializer/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "encoding-sniffer/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
-    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+    "jsdom/parse5": ["parse5@8.0.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA=="],
+
+    "jsdom/whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
@@ -1447,9 +1569,13 @@
 
     "shadcn/postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
+    "strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
     "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1471,9 +1597,11 @@
 
     "cliui/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+    "cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jsdom/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
@@ -1529,12 +1657,8 @@
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
-    "wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
     "yargs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "yargs/string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
   }
 }

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[test]
+environment = "happy-dom"
+preload = ["./src/test-setup.ts"]

--- a/package.json
+++ b/package.json
@@ -31,11 +31,17 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@types/jsdom": "^28.0.1",
     "@types/node": "^22.5.4",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",
     "bun-types": "^1.3.11",
+    "happy-dom": "^20.8.9",
+    "jsdom": "^29.0.1",
     "typescript": "^5.8.0",
     "vite": "^6.3.0"
   }

--- a/src/components/command-picker.test.tsx
+++ b/src/components/command-picker.test.tsx
@@ -1,0 +1,269 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CommandPicker } from './command-picker';
+
+afterEach(cleanup);
+
+const items = [{ name: 'alpha/' }, { name: 'beta/' }, { name: 'gamma/' }];
+
+describe('CommandPicker', () => {
+  describe('rendering', () => {
+    it('shows all items', () => {
+      render(<CommandPicker items={items} onSelect={mock()} />);
+      // getByText throws if the element is absent — sufficient for presence assertion
+      screen.getByText('alpha/');
+      screen.getByText('beta/');
+      screen.getByText('gamma/');
+    });
+
+    it('shows meta text when provided', () => {
+      render(
+        <CommandPicker
+          items={[{ name: 'alpha/', meta: 'lead +2' }]}
+          onSelect={mock()}
+        />,
+      );
+      screen.getByText('lead +2');
+    });
+
+    it('shows create button when onCreate provided', () => {
+      render(
+        <CommandPicker
+          items={items}
+          onSelect={mock()}
+          createLabel="new team"
+          onCreate={mock()}
+        />,
+      );
+      screen.getByText('+ new team');
+    });
+
+    it('omits create button when onCreate not provided', () => {
+      render(<CommandPicker items={items} onSelect={mock()} />);
+      expect(screen.queryByText(/^\+/)).toBeNull();
+    });
+  });
+
+  describe('filtering', () => {
+    it('filters items by query', async () => {
+      const user = userEvent.setup();
+      render(<CommandPicker items={items} onSelect={mock()} />);
+
+      await user.type(screen.getByPlaceholderText('filter...'), 'al');
+
+      screen.getByText('alpha/');
+      expect(screen.queryByText('beta/')).toBeNull();
+      expect(screen.queryByText('gamma/')).toBeNull();
+    });
+
+    it('is case-insensitive', async () => {
+      const user = userEvent.setup();
+      render(<CommandPicker items={items} onSelect={mock()} />);
+
+      await user.type(screen.getByPlaceholderText('filter...'), 'BETA');
+
+      screen.getByText('beta/');
+      expect(screen.queryByText('alpha/')).toBeNull();
+    });
+
+    it('shows no-matches message when filter has no results', async () => {
+      const user = userEvent.setup();
+      render(<CommandPicker items={items} onSelect={mock()} />);
+
+      await user.type(screen.getByPlaceholderText('filter...'), 'zzz');
+
+      screen.getByText('(no matches)');
+    });
+  });
+
+  describe('keyboard navigation', () => {
+    it('selects item at cursor on Enter', async () => {
+      const user = userEvent.setup();
+      const onSelect = mock();
+      render(<CommandPicker items={items} onSelect={onSelect} />);
+
+      await user.keyboard('{Enter}');
+
+      expect(onSelect).toHaveBeenCalledWith(0);
+    });
+
+    it('moves cursor down with ArrowDown', async () => {
+      const user = userEvent.setup();
+      const onSelect = mock();
+      render(<CommandPicker items={items} onSelect={onSelect} />);
+
+      await user.keyboard('{ArrowDown}{Enter}');
+
+      expect(onSelect).toHaveBeenCalledWith(1);
+    });
+
+    it('moves cursor up with ArrowUp', async () => {
+      const user = userEvent.setup();
+      const onSelect = mock();
+      render(<CommandPicker items={items} onSelect={onSelect} />);
+
+      await user.keyboard('{ArrowDown}{ArrowDown}{ArrowUp}{Enter}');
+
+      expect(onSelect).toHaveBeenCalledWith(1);
+    });
+
+    it('does not move cursor below last item', async () => {
+      const user = userEvent.setup();
+      const onSelect = mock();
+      render(<CommandPicker items={items} onSelect={onSelect} />);
+
+      // ArrowDown many times — should clamp at last item (index 2)
+      await user.keyboard(
+        '{ArrowDown}{ArrowDown}{ArrowDown}{ArrowDown}{Enter}',
+      );
+
+      expect(onSelect).toHaveBeenCalledWith(2);
+    });
+
+    it('does not move cursor above first item', async () => {
+      const user = userEvent.setup();
+      const onSelect = mock();
+      render(<CommandPicker items={items} onSelect={onSelect} />);
+
+      await user.keyboard('{ArrowUp}{Enter}');
+
+      expect(onSelect).toHaveBeenCalledWith(0);
+    });
+
+    it('calls onClose on Escape', async () => {
+      const user = userEvent.setup();
+      const onClose = mock();
+      render(
+        <CommandPicker items={items} onSelect={mock()} onClose={onClose} />,
+      );
+
+      await user.keyboard('{Escape}');
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('passes original index when filtered', async () => {
+      const user = userEvent.setup();
+      const onSelect = mock();
+      render(<CommandPicker items={items} onSelect={onSelect} />);
+
+      await user.type(screen.getByPlaceholderText('filter...'), 'bet');
+      await user.keyboard('{Enter}');
+
+      // 'beta/' is index 1 in the original items array
+      expect(onSelect).toHaveBeenCalledWith(1);
+    });
+
+    it('resets cursor to 0 when filter changes', async () => {
+      const user = userEvent.setup();
+      const onSelect = mock();
+      render(<CommandPicker items={items} onSelect={onSelect} />);
+
+      // Move down to beta, then filter — cursor should reset
+      await user.keyboard('{ArrowDown}');
+      await user.type(screen.getByPlaceholderText('filter...'), 'al');
+      await user.keyboard('{Enter}');
+
+      expect(onSelect).toHaveBeenCalledWith(0); // alpha/ is index 0
+    });
+  });
+
+  describe('mouse interaction', () => {
+    it('selects item on click', async () => {
+      const user = userEvent.setup();
+      const onSelect = mock();
+      render(<CommandPicker items={items} onSelect={onSelect} />);
+
+      await user.click(screen.getByText('gamma/'));
+
+      expect(onSelect).toHaveBeenCalledWith(2);
+    });
+
+    it('updates cursor on hover', async () => {
+      const user = userEvent.setup();
+      const onSelect = mock();
+      render(<CommandPicker items={items} onSelect={onSelect} />);
+
+      await user.hover(screen.getByText('gamma/'));
+      await user.keyboard('{Enter}');
+
+      expect(onSelect).toHaveBeenCalledWith(2);
+    });
+  });
+
+  describe('create flow', () => {
+    it('switches to create mode on button click', async () => {
+      const user = userEvent.setup();
+      render(
+        <CommandPicker
+          items={items}
+          onSelect={mock()}
+          createLabel="new team"
+          onCreate={mock()}
+        />,
+      );
+
+      await user.click(screen.getByText('+ new team'));
+
+      screen.getByPlaceholderText('new team');
+      screen.getByText('name:');
+    });
+
+    it('calls onCreate with trimmed name on Enter', async () => {
+      const user = userEvent.setup();
+      const onCreate = mock();
+      render(
+        <CommandPicker
+          items={items}
+          onSelect={mock()}
+          createLabel="new team"
+          onCreate={onCreate}
+        />,
+      );
+
+      await user.click(screen.getByText('+ new team'));
+      await user.type(screen.getByPlaceholderText('new team'), '  my team  ');
+      await user.keyboard('{Enter}');
+
+      expect(onCreate).toHaveBeenCalledWith('my team');
+    });
+
+    it('does not call onCreate on Enter with empty name', async () => {
+      const user = userEvent.setup();
+      const onCreate = mock();
+      render(
+        <CommandPicker
+          items={items}
+          onSelect={mock()}
+          createLabel="new team"
+          onCreate={onCreate}
+        />,
+      );
+
+      await user.click(screen.getByText('+ new team'));
+      await user.keyboard('{Enter}');
+
+      expect(onCreate).not.toHaveBeenCalled();
+    });
+
+    it('returns to list on Escape in create mode', async () => {
+      const user = userEvent.setup();
+      render(
+        <CommandPicker
+          items={items}
+          onSelect={mock()}
+          createLabel="new team"
+          onCreate={mock()}
+        />,
+      );
+
+      await user.click(screen.getByText('+ new team'));
+      expect(screen.queryByPlaceholderText('filter...')).toBeNull();
+
+      await user.keyboard('{Escape}');
+
+      screen.getByPlaceholderText('filter...');
+    });
+  });
+});

--- a/src/components/command-picker.tsx
+++ b/src/components/command-picker.tsx
@@ -1,0 +1,181 @@
+import type React from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '~/lib/utils';
+
+export type PickerItem = {
+  name: string;
+  meta?: string;
+  highlight?: boolean;
+};
+
+export function CommandPicker({
+  items,
+  onSelect,
+  onClose,
+  createLabel,
+  onCreate,
+}: {
+  items: PickerItem[];
+  onSelect: (originalIdx: number) => void;
+  onClose?: () => void;
+  createLabel?: string;
+  onCreate?: (name: string) => void;
+}) {
+  const [query, setQuery] = useState('');
+  const [cursor, setCursor] = useState(0);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const createInputRef = useRef<HTMLInputElement>(null);
+
+  const filtered = useMemo(
+    () =>
+      items.filter((item) =>
+        item.name.toLowerCase().includes(query.toLowerCase()),
+      ),
+    [items, query],
+  );
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset cursor when query changes OR when filtered set shrinks (cursor can go out-of-bounds without a query change, e.g. items prop updates)
+  useEffect(() => {
+    setCursor(0);
+  }, [query, filtered.length]);
+
+  useEffect(() => {
+    if (creating) {
+      createInputRef.current?.focus();
+    } else {
+      inputRef.current?.focus();
+    }
+  }, [creating]);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  function stopCreating() {
+    setCreating(false);
+    setNewName('');
+  }
+
+  function handleCreateKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' && newName.trim()) {
+      onCreate?.(newName.trim());
+      stopCreating();
+      e.preventDefault();
+    } else if (e.key === 'Escape') {
+      stopCreating();
+      e.preventDefault();
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    switch (e.key) {
+      case 'Escape':
+        onClose?.();
+        e.preventDefault();
+        break;
+      case 'ArrowDown':
+        setCursor((c) => Math.min(c + 1, Math.max(filtered.length - 1, 0)));
+        e.preventDefault();
+        break;
+      case 'ArrowUp':
+        setCursor((c) => Math.max(c - 1, 0));
+        e.preventDefault();
+        break;
+      case 'Enter': {
+        const item = filtered[cursor];
+        if (item) {
+          onSelect(items.indexOf(item));
+        }
+        e.preventDefault();
+        break;
+      }
+    }
+  }
+
+  return (
+    <div className="bg-background">
+      <div className="px-4 py-1.5 border-b border-border/30 flex items-center gap-1.5">
+        {creating ? (
+          <>
+            <span className="text-muted-foreground text-xs select-none shrink-0">
+              name:
+            </span>
+            <input
+              ref={createInputRef}
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              onKeyDown={handleCreateKeyDown}
+              placeholder={createLabel ?? 'new name...'}
+              className="flex-1 bg-transparent border-none outline-none text-sm text-foreground placeholder:text-muted-foreground/40 font-mono"
+            />
+          </>
+        ) : (
+          <>
+            <span className="text-primary text-sm select-none">❯</span>
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={handleKeyDown}
+              placeholder="filter..."
+              className="flex-1 bg-transparent border-none outline-none text-sm text-foreground placeholder:text-muted-foreground/40 font-mono"
+            />
+          </>
+        )}
+      </div>
+      <div className="max-h-60 overflow-y-auto">
+        {!creating && filtered.length === 0 && (
+          <div className="px-4 py-1.5 text-sm text-muted-foreground/50 italic font-mono">
+            (no matches)
+          </div>
+        )}
+        {!creating &&
+          filtered.map((item, i) => (
+            <button
+              key={item.name}
+              type="button"
+              onClick={() => onSelect(items.indexOf(item))}
+              onMouseEnter={() => setCursor(i)}
+              className={cn(
+                'flex items-baseline justify-between text-left w-full px-4 py-1 text-sm font-mono transition-colors',
+                i === cursor
+                  ? 'bg-accent text-accent-foreground'
+                  : 'hover:bg-accent/40',
+              )}
+            >
+              <span
+                className={cn(
+                  item.highlight ? 'text-secondary' : 'text-foreground',
+                )}
+              >
+                {item.name}
+              </span>
+              {item.meta && (
+                <span
+                  className={cn(
+                    'text-xs ml-4 truncate',
+                    item.highlight
+                      ? 'text-secondary/70'
+                      : 'text-muted-foreground/60',
+                  )}
+                >
+                  {item.meta}
+                </span>
+              )}
+            </button>
+          ))}
+        {!creating && onCreate && (
+          <button
+            type="button"
+            onClick={() => setCreating(true)}
+            className="flex items-center gap-1 text-left w-full px-4 py-1 text-sm font-mono text-muted-foreground/50 hover:text-primary hover:bg-accent/40 transition-colors border-t border-border/20"
+          >
+            + {createLabel ?? 'new'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/db/sessions.ts
+++ b/src/db/sessions.ts
@@ -100,8 +100,12 @@ export function getSession(
 }
 
 /** Resets all sessions that are stuck in 'working' state back to 'idle'. */
-export function resetStuckSessions(db: Database, teamId: string): void {
-  for (const session of getSessionsByTeam(db, teamId)) {
+export function resetStuckSessions(
+  db: Database,
+  teamId: string,
+  projectId?: string,
+): void {
+  for (const session of getSessionsByTeam(db, teamId, projectId)) {
     if (session.status === 'working') {
       upsertSession(
         db,

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,10 @@
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useServerFn } from '@tanstack/react-start';
+import { useState } from 'react';
+import { CommandPicker } from '~/components/command-picker';
 import { Separator } from '~/components/ui/separator';
-import { listTeams } from '~/server/teams';
+import type { TeamMeta } from '~/server/teams';
+import { createTeam, listTeams } from '~/server/teams';
 
 export const Route = createFileRoute('/')({
   loader: () => listTeams(),
@@ -8,48 +12,51 @@ export const Route = createFileRoute('/')({
 });
 
 function TeamsPage() {
-  const teams = Route.useLoaderData();
+  const [teams, setTeams] = useState<TeamMeta[]>(Route.useLoaderData());
   const navigate = useNavigate();
+  const createTeamFn = useServerFn(createTeam);
 
   return (
-    <div className="flex h-screen items-start justify-center pt-32">
-      <div className="w-full max-w-sm">
-        <div className="mb-4 flex items-center justify-between">
-          <span className="text-xs font-mono text-muted-foreground">
-            nightshift
-          </span>
-          <span className="text-xs font-mono text-muted-foreground">teams</span>
+    <div className="flex flex-col h-screen bg-background overflow-hidden font-mono">
+      {/* Empty content area pushes picker to the bottom */}
+      <div className="flex-1" />
+
+      {/* Picker floats above the footer separator */}
+      <div className="relative shrink-0">
+        <div className="absolute bottom-full inset-x-0 z-50 bg-background border border-border/50 shadow-lg">
+          {teams.length === 0 ? (
+            <div className="px-4 py-2 text-sm text-muted-foreground">
+              No teams yet — run{' '}
+              <code className="text-foreground">nightshift team create</code>
+            </div>
+          ) : (
+            <CommandPicker
+              items={teams.map((t) => ({
+                name: `${t.name}/`,
+                meta: `${t.lead} +${t.members.length}`,
+              }))}
+              onSelect={(i) => {
+                const team = teams[i];
+                if (team) {
+                  navigate({
+                    to: '/teams/$teamId',
+                    params: { teamId: team.name },
+                  });
+                }
+              }}
+              createLabel="new team"
+              onCreate={async (name) => {
+                const team = await createTeamFn({ data: { name } });
+                setTeams((prev) => [...prev, team]);
+              }}
+            />
+          )}
         </div>
-        <Separator className="mb-1" />
-        {teams.length === 0 ? (
-          <p className="py-3 text-sm text-muted-foreground font-mono">
-            No teams yet — run{' '}
-            <code className="text-foreground">nightshift team create</code>
-          </p>
-        ) : (
-          <ul>
-            {teams.map((team) => (
-              <li key={team.name}>
-                <button
-                  type="button"
-                  className="w-full text-left px-2 py-1 text-sm font-mono hover:bg-accent hover:text-accent-foreground rounded-sm flex items-center justify-between group"
-                  onClick={() =>
-                    navigate({
-                      to: '/teams/$teamId',
-                      params: { teamId: team.name },
-                    })
-                  }
-                >
-                  <span>{team.name}/</span>
-                  <span className="text-xs text-muted-foreground group-hover:text-accent-foreground truncate ml-4">
-                    {team.lead} +{team.members.length}
-                  </span>
-                </button>
-              </li>
-            ))}
-          </ul>
-        )}
-        <Separator className="mt-1" />
+        <Separator />
+        <div className="px-4 py-1 flex items-center gap-1.5 text-xs text-muted-foreground/50">
+          <span className="text-primary">~/</span>
+          <span>nightshift</span>
+        </div>
       </div>
     </div>
   );

--- a/src/routes/teams/$teamId.test.tsx
+++ b/src/routes/teams/$teamId.test.tsx
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { Breadcrumb, type ViewState } from './$teamId';
+
+afterEach(cleanup);
+
+// ── Breadcrumb ─────────────────────────────────────────────────────────────
+
+describe('Breadcrumb', () => {
+  it('renders ~/teamId for chat view', () => {
+    render(<Breadcrumb view={{ type: 'chat' }} teamId="myteam" />);
+    screen.getByText('~/myteam');
+  });
+
+  it('renders ~/teamId and (projectName) as separate spans for project-chat', () => {
+    const view: ViewState = {
+      type: 'project-chat',
+      projectId: 'p1',
+      projectName: 'my-project',
+    };
+    render(<Breadcrumb view={view} teamId="myteam" />);
+
+    screen.getByText('~/myteam');
+    screen.getByText('(my-project)');
+  });
+
+  it('project-chat: path segment is primary, project label is secondary', () => {
+    const view: ViewState = {
+      type: 'project-chat',
+      projectId: 'p1',
+      projectName: 'my-project',
+    };
+    render(<Breadcrumb view={view} teamId="myteam" />);
+
+    const path = screen.getByText('~/myteam');
+    const label = screen.getByText('(my-project)');
+
+    expect(path.className).toContain('text-primary');
+    expect(label.className).toContain('text-secondary');
+  });
+
+  it('renders ~/teamId/agentName for agent-session', () => {
+    const view: ViewState = { type: 'agent-session', agentName: 'aria' };
+    render(<Breadcrumb view={view} teamId="myteam" />);
+
+    screen.getByText(/myteam\/aria/);
+  });
+
+  it('agent-session: entire path is primary', () => {
+    const view: ViewState = { type: 'agent-session', agentName: 'aria' };
+    render(<Breadcrumb view={view} teamId="myteam" />);
+
+    const el = screen.getByText(/myteam\/aria/);
+    expect(el.className).toContain('text-primary');
+    expect(el.className).not.toContain('text-secondary');
+  });
+});
+
+// ── Input mode / disable regression ───────────────────────────────────────
+//
+// Regression for: mode stuck at 'insert' after textarea is disabled (during
+// send), causing the global keydown handler to return early and swallow all
+// input once sending completes and the textarea is re-enabled.
+//
+// Fix: onBlur resets mode to 'normal' so the user can re-enter insert mode.
+
+function InputModeHarness({ disabled }: { disabled: boolean }) {
+  const [mode, setMode] = useState<'normal' | 'insert'>('normal');
+  const [value, setValue] = useState('');
+
+  return (
+    <div>
+      <span data-testid="mode">{mode}</span>
+      <textarea
+        data-testid="input"
+        disabled={disabled}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onFocus={() => setMode('insert')}
+        onBlur={() => setMode('normal')}
+      />
+    </div>
+  );
+}
+
+function InputModeWithToggle() {
+  const [sending, setSending] = useState(false);
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="toggle-send"
+        onClick={() => setSending((s) => !s)}
+      >
+        toggle
+      </button>
+      <InputModeHarness disabled={sending} />
+    </div>
+  );
+}
+
+describe('input mode / disable regression', () => {
+  it('mode is normal initially', () => {
+    render(<InputModeHarness disabled={false} />);
+    expect(screen.getByTestId('mode').textContent).toBe('normal');
+  });
+
+  it('mode becomes insert when textarea is focused', async () => {
+    const user = userEvent.setup();
+    render(<InputModeHarness disabled={false} />);
+
+    await user.click(screen.getByTestId('input'));
+
+    expect(screen.getByTestId('mode').textContent).toBe('insert');
+  });
+
+  it('mode resets to normal when textarea loses focus (onBlur)', async () => {
+    const user = userEvent.setup();
+    render(<InputModeHarness disabled={false} />);
+
+    await user.click(screen.getByTestId('input'));
+    expect(screen.getByTestId('mode').textContent).toBe('insert');
+
+    await user.tab(); // move focus away
+    expect(screen.getByTestId('mode').textContent).toBe('normal');
+  });
+
+  it('mode resets to normal when textarea is disabled (regression)', async () => {
+    // This is the bug: textarea is focused (insert mode), then disabled due to
+    // a send in-flight. Without onBlur, mode stays 'insert' forever and the
+    // user cannot type after sending completes.
+    const user = userEvent.setup();
+    render(<InputModeWithToggle />);
+
+    // Enter insert mode by clicking the textarea
+    await user.click(screen.getByTestId('input'));
+    expect(screen.getByTestId('mode').textContent).toBe('insert');
+
+    // Simulate send start — textarea becomes disabled → blur fires
+    await user.click(screen.getByTestId('toggle-send'));
+    expect((screen.getByTestId('input') as HTMLTextAreaElement).disabled).toBe(
+      true,
+    );
+
+    // Mode must have reset so the user can recover
+    expect(screen.getByTestId('mode').textContent).toBe('normal');
+
+    // Simulate send complete — textarea re-enabled
+    await user.click(screen.getByTestId('toggle-send'));
+    expect((screen.getByTestId('input') as HTMLTextAreaElement).disabled).toBe(
+      false,
+    );
+
+    // User can click and type again
+    await user.click(screen.getByTestId('input'));
+    expect(screen.getByTestId('mode').textContent).toBe('insert');
+  });
+});

--- a/src/routes/teams/$teamId.tsx
+++ b/src/routes/teams/$teamId.tsx
@@ -1,40 +1,21 @@
-import { Link, createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useServerFn } from '@tanstack/react-start';
-import { useEffect, useRef, useState } from 'react';
+import type React from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
-import { Badge } from '~/components/ui/badge';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '~/components/ui/breadcrumb';
-import { Button } from '~/components/ui/button';
-import { Input } from '~/components/ui/input';
-import { ScrollArea } from '~/components/ui/scroll-area';
 import { Separator } from '~/components/ui/separator';
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
-  SidebarInset,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarProvider,
-} from '~/components/ui/sidebar';
 import type { Message } from '~/db/messages';
+import type { Project } from '~/db/projects';
 import { cn } from '~/lib/utils';
 import {
   type AgentSessionMessage,
+  createNewProject,
   getAgentSession,
   getAgentStatuses,
   getLatestMessages,
+  getProjectMessages as getProjectMessagesFn,
   getTeamView,
+  sendProjectMessage as sendProjectMessageFn,
   sendTeamMessage,
 } from '~/server/team-data';
 
@@ -42,6 +23,8 @@ export const Route = createFileRoute('/teams/$teamId')({
   loader: ({ params }) => getTeamView({ data: { teamId: params.teamId } }),
   component: TeamPage,
 });
+
+// ── Types ──────────────────────────────────────────────────────────────────
 
 type AgentInfo = {
   name: string;
@@ -56,43 +39,240 @@ type SessionData = {
   statusText: string | null;
 };
 
-function AgentStatusDot({ status }: { status: 'idle' | 'working' }) {
-  return (
-    <span
-      className={cn(
-        'inline-block size-2 rounded-full shrink-0',
-        status === 'working'
-          ? 'bg-primary animate-pulse'
-          : 'bg-muted-foreground/40',
-      )}
-    />
-  );
+export type ViewState =
+  | { type: 'chat' }
+  | { type: 'project-chat'; projectId: string; projectName: string }
+  | { type: 'agent-session'; agentName: string };
+
+type OverlayState =
+  | { kind: 'projects'; cursor: number }
+  | { kind: 'projects-create' }
+  | { kind: 'agents'; cursor: number }
+  | { kind: 'mention'; atStart: number; query: string; cursor: number };
+
+type ContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'thinking'; thinking: string }
+  | { type: 'tool_use'; name: string; input: unknown }
+  | { type: 'tool_result'; content: unknown }
+  | { type: string; [key: string]: unknown };
+
+type NavBlock =
+  | {
+      kind: 'chat';
+      id: string;
+      sender: string;
+      content: string;
+      isUser: boolean;
+    }
+  | {
+      kind: 'session';
+      id: string;
+      role: string;
+      isUser: boolean;
+      block: ContentBlock;
+    };
+
+// ── Breadcrumb ─────────────────────────────────────────────────────────────
+
+export function Breadcrumb({
+  view,
+  teamId,
+}: {
+  view: ViewState;
+  teamId: string;
+}) {
+  switch (view.type) {
+    case 'chat':
+      return <span className="text-primary">~/{teamId}</span>;
+    case 'project-chat':
+      return (
+        <>
+          <span className="text-primary">~/{teamId}</span>
+          <span className="text-secondary ml-1">({view.projectName})</span>
+        </>
+      );
+    case 'agent-session':
+      return (
+        <span className="text-primary">
+          ~/{teamId}/{view.agentName}
+        </span>
+      );
+  }
 }
+
+// ── Markdown ───────────────────────────────────────────────────────────────
+
+function FlatHeading({ children }: { children?: React.ReactNode }) {
+  return <p className="font-bold">{children}</p>;
+}
+const markdownComponents = {
+  h1: FlatHeading,
+  h2: FlatHeading,
+  h3: FlatHeading,
+  h4: FlatHeading,
+  h5: FlatHeading,
+  h6: FlatHeading,
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function flattenSessionBlocks(messages: AgentSessionMessage[]): NavBlock[] {
+  const result: NavBlock[] = [];
+  for (const msg of messages) {
+    if (msg.type === 'system') continue;
+    const raw = msg.message;
+    const role = (raw?.role as string | undefined) ?? msg.type;
+    const isUser = role === 'user';
+    const content = raw?.content;
+    const blocks: ContentBlock[] = (() => {
+      if (!content) return [];
+      if (typeof content === 'string') return [{ type: 'text', text: content }];
+      if (Array.isArray(content)) return content as ContentBlock[];
+      return [];
+    })();
+    if (isUser) continue;
+    for (let i = 0; i < blocks.length; i++) {
+      result.push({
+        kind: 'session',
+        id: `${msg.uuid}-${i}`,
+        role,
+        isUser,
+        block: blocks[i],
+      });
+    }
+  }
+  return result;
+}
+
+function navBlockText(b: NavBlock): string {
+  if (b.kind === 'chat') return b.content;
+  if (b.kind === 'session' && b.block.type === 'text')
+    return (b.block as { type: 'text'; text: string }).text;
+  if (b.kind === 'session' && b.block.type === 'thinking')
+    return (b.block as { type: 'thinking'; thinking: string }).thinking;
+  return '';
+}
+
+// ── Main component ─────────────────────────────────────────────────────────
 
 function TeamPage() {
   const initialData = Route.useLoaderData();
   const { teamId } = Route.useParams();
+  const navigate = useNavigate();
 
   const [messages, setMessages] = useState<Message[]>(initialData.messages);
   const [agents, setAgents] = useState<AgentInfo[]>(initialData.agents);
+  const [projects, setProjects] = useState<Project[]>(initialData.projects);
   const [input, setInput] = useState('');
   const [sending, setSending] = useState(false);
-  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
+
+  const [mode, setMode] = useState<'insert' | 'normal'>('normal');
+  const [view, setView] = useState<ViewState>({ type: 'chat' });
+  const [overlay, setOverlay] = useState<OverlayState | null>(null);
+  const [focusedIdx, setFocusedIdx] = useState(-1);
+
+  const [projectMessages, setProjectMessages] = useState<Message[]>([]);
+  const [projectSending, setProjectSending] = useState(false);
   const [sessionData, setSessionData] = useState<SessionData | null>(null);
+
+  const modeRef = useRef(mode);
+  const viewRef = useRef(view);
+  const overlayRef = useRef(overlay);
+  const focusedIdxRef = useRef(focusedIdx);
+  const navBlocksRef = useRef<NavBlock[]>([]);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
-  const sessionBottomRef = useRef<HTMLDivElement>(null);
+  const hasInitialScrolled = useRef(false);
+
+  useEffect(() => {
+    modeRef.current = mode;
+  }, [mode]);
+  useEffect(() => {
+    viewRef.current = view;
+  }, [view]);
+  useEffect(() => {
+    overlayRef.current = overlay;
+  }, [overlay]);
+  useEffect(() => {
+    focusedIdxRef.current = focusedIdx;
+  }, [focusedIdx]);
 
   const sendFn = useServerFn(sendTeamMessage);
   const getStatusesFn = useServerFn(getAgentStatuses);
   const getAgentSessionFn = useServerFn(getAgentSession);
   const getMessagesFn = useServerFn(getLatestMessages);
+  const getProjectMsgsFn = useServerFn(getProjectMessagesFn);
+  const sendProjectMsgFn = useServerFn(sendProjectMessageFn);
+  const createProjectFn = useServerFn(createNewProject);
 
-  // Derive the selected agent's status so the session-poll effect only
-  // re-runs when that specific value changes, not on every agents update.
+  function msgToNavBlocks(m: Message): NavBlock[] {
+    const sender = m.sender === 'user' ? 'you' : m.sender;
+    const isUser = m.sender === 'user';
+    return m.content
+      .split('\n\n')
+      .map((chunk) => chunk.trim())
+      .filter((chunk) => chunk.length > 0)
+      .map((chunk, i) => ({
+        kind: 'chat' as const,
+        id: `${m.id}-p${i}`,
+        sender,
+        content: chunk,
+        isUser,
+      }));
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: msgToNavBlocks and flattenSessionBlocks are stable
+  const navBlocks: NavBlock[] = useMemo(() => {
+    if (view.type === 'chat') return messages.flatMap(msgToNavBlocks);
+    if (view.type === 'project-chat')
+      return projectMessages.flatMap(msgToNavBlocks);
+    if (view.type === 'agent-session' && sessionData)
+      return flattenSessionBlocks(sessionData.messages);
+    return [];
+  }, [view, messages, projectMessages, sessionData]);
+
+  useEffect(() => {
+    navBlocksRef.current = navBlocks;
+  }, [navBlocks]);
+
+  const pickerItems = useMemo(() => {
+    if (overlay?.kind === 'projects') {
+      return projects.filter((p) =>
+        p.name.toLowerCase().includes(input.toLowerCase()),
+      );
+    }
+    if (overlay?.kind === 'agents') {
+      return agents.filter((a) =>
+        a.name.toLowerCase().includes(input.toLowerCase()),
+      );
+    }
+    return [];
+  }, [overlay, projects, agents, input]);
+
+  const mentionFilteredAgents = useMemo(() => {
+    if (!overlay || overlay.kind !== 'mention') return [];
+    return agents.filter((a) =>
+      a.name.toLowerCase().includes(overlay.query.toLowerCase()),
+    );
+  }, [overlay, agents]);
+
+  const showInlinePicker =
+    overlay !== null &&
+    overlay.kind !== 'projects-create' &&
+    (overlay.kind !== 'mention' || mentionFilteredAgents.length > 0);
+
+  const currentProjectId = view.type === 'project-chat' ? view.projectId : null;
+
   const selectedAgentStatus =
-    agents.find((a) => a.name === selectedAgent)?.status ?? 'idle';
+    view.type === 'agent-session'
+      ? (agents.find(
+          (a) =>
+            a.name ===
+            (view as { type: 'agent-session'; agentName: string }).agentName,
+        )?.status ?? 'idle')
+      : 'idle';
 
-  // Poll agent statuses and messages while a send is in flight
   useEffect(() => {
     if (!sending) return;
     const id = setInterval(async () => {
@@ -111,36 +291,77 @@ function TeamPage() {
     return () => clearInterval(id);
   }, [sending, teamId, getStatusesFn, getMessagesFn]);
 
-  // Poll session history while an agent is selected
   useEffect(() => {
-    if (!selectedAgent) return;
+    if (!projectSending || !currentProjectId) return;
+    const projectId = currentProjectId;
+    const id = setInterval(async () => {
+      const [sessions, freshMsgs] = await Promise.all([
+        getStatusesFn({ data: { teamId, projectId } }),
+        getProjectMsgsFn({ data: { teamId, projectId } }),
+      ]);
+      setAgents((prev) =>
+        prev.map((a) => {
+          const s = sessions.find((s) => s.agent_name === a.name);
+          return s ? { ...a, status: s.status, statusText: s.status_text } : a;
+        }),
+      );
+      setProjectMessages(freshMsgs as Message[]);
+    }, 1500);
+    return () => clearInterval(id);
+  }, [
+    projectSending,
+    currentProjectId,
+    teamId,
+    getStatusesFn,
+    getProjectMsgsFn,
+  ]);
 
+  useEffect(() => {
+    if (view.type !== 'agent-session') return;
+    const { agentName } = view;
     async function fetchSession() {
-      if (!selectedAgent) return;
-      const data = await getAgentSessionFn({
-        data: { teamId, agentName: selectedAgent },
-      });
+      const data = await getAgentSessionFn({ data: { teamId, agentName } });
       setSessionData(data as SessionData);
       setTimeout(
-        () => sessionBottomRef.current?.scrollIntoView({ behavior: 'smooth' }),
+        () => bottomRef.current?.scrollIntoView({ behavior: 'instant' }),
         50,
       );
     }
-
     fetchSession();
-
     if (selectedAgentStatus !== 'working') return;
-
     const id = setInterval(fetchSession, 2000);
     return () => clearInterval(id);
-  }, [selectedAgent, selectedAgentStatus, teamId, getAgentSessionFn]);
+  }, [view, selectedAgentStatus, teamId, getAgentSessionFn]);
 
-  async function handleSend() {
-    const content = input.trim();
-    if (!content) return;
-    setInput('');
+  useEffect(() => {
+    if (view.type !== 'project-chat') return;
+    const { projectId } = view;
+    getProjectMsgsFn({ data: { teamId, projectId } }).then((msgs) => {
+      setProjectMessages(msgs as Message[]);
+      setTimeout(
+        () => bottomRef.current?.scrollIntoView({ behavior: 'instant' }),
+        50,
+      );
+    });
+  }, [view, teamId, getProjectMsgsFn]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: messages/projectMessages trigger scroll
+  useEffect(() => {
+    const behavior = hasInitialScrolled.current ? 'smooth' : 'instant';
+    hasInitialScrolled.current = true;
+    bottomRef.current?.scrollIntoView({ behavior });
+  }, [messages, projectMessages]);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: input triggers DOM scrollHeight recalc
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  }, [input]);
+
+  async function handleTeamSend(content: string) {
     setSending(true);
-
     const userMsg: Message = {
       id: crypto.randomUUID(),
       team_id: teamId,
@@ -151,10 +372,8 @@ function TeamPage() {
       created_at: Date.now(),
     };
     setMessages((prev) => [...prev, userMsg]);
-
     try {
       await sendFn({ data: { teamId, content } });
-      // Final sync: pick up any messages that arrived after the last poll
       const [finalMessages, sessions] = await Promise.all([
         getMessagesFn({ data: { teamId } }),
         getStatusesFn({ data: { teamId } }),
@@ -166,347 +385,866 @@ function TeamPage() {
           return s ? { ...a, status: s.status, statusText: s.status_text } : a;
         }),
       );
-      setTimeout(
-        () => bottomRef.current?.scrollIntoView({ behavior: 'smooth' }),
-        50,
-      );
     } finally {
       setSending(false);
     }
   }
 
+  async function handleProjectSend(projectId: string, content: string) {
+    setProjectSending(true);
+    const userMsg: Message = {
+      id: crypto.randomUUID(),
+      team_id: teamId,
+      project_id: projectId,
+      sender: 'user',
+      content,
+      mentions: '[]',
+      created_at: Date.now(),
+    };
+    setProjectMessages((prev) => [...prev, userMsg]);
+    try {
+      await sendProjectMsgFn({ data: { teamId, projectId, content } });
+      const [finalMsgs, sessions] = await Promise.all([
+        getProjectMsgsFn({ data: { teamId, projectId } }),
+        getStatusesFn({ data: { teamId } }),
+      ]);
+      setProjectMessages(finalMsgs as Message[]);
+      setAgents((prev) =>
+        prev.map((a) => {
+          const s = sessions.find((s) => s.agent_name === a.name);
+          return s ? { ...a, status: s.status, statusText: s.status_text } : a;
+        }),
+      );
+    } finally {
+      setProjectSending(false);
+    }
+  }
+
+  function handleSend() {
+    const content = input.trim();
+    if (!content) return;
+    setInput('');
+    if (view.type === 'project-chat') {
+      handleProjectSend(view.projectId, content);
+    } else {
+      handleTeamSend(content);
+    }
+  }
+
+  function insertMention(name: string, atStart: number) {
+    const textarea = inputRef.current;
+    if (!textarea) return;
+    const cursorEnd = textarea.selectionStart ?? input.length;
+    const newText = `${input.slice(0, atStart)}@${name} ${input.slice(cursorEnd)}`;
+    setInput(newText);
+    const newCursor = atStart + name.length + 2;
+    requestAnimationFrame(() =>
+      textarea.setSelectionRange(newCursor, newCursor),
+    );
+  }
+
+  function closePicker() {
+    setInput('');
+    setOverlay(null);
+    setMode('normal');
+    inputRef.current?.blur();
+  }
+
+  // ── Global keyboard handler ───────────────────────────────────────────────
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      const currentMode = modeRef.current;
+      const currentView = viewRef.current;
+      const currentOverlay = overlayRef.current;
+      const currentFocused = focusedIdxRef.current;
+      const blocks = navBlocksRef.current;
+
+      if (currentMode === 'insert') {
+        if (e.key === 'Escape') {
+          if (currentOverlay?.kind === 'mention') {
+            setOverlay(null);
+          } else if (
+            currentOverlay?.kind === 'projects' ||
+            currentOverlay?.kind === 'agents'
+          ) {
+            setInput('');
+            setOverlay(null);
+            setMode('normal');
+            inputRef.current?.blur();
+          } else if (currentOverlay?.kind === 'projects-create') {
+            // Back to projects list
+            setOverlay({ kind: 'projects', cursor: 0 });
+            setInput('');
+          } else {
+            setMode('normal');
+            inputRef.current?.blur();
+          }
+          e.preventDefault();
+        }
+        return;
+      }
+
+      // Normal mode: block global shortcuts while overlay is open
+      if (currentOverlay !== null) return;
+
+      switch (e.key) {
+        case 'i':
+          setMode('insert');
+          inputRef.current?.focus();
+          e.preventDefault();
+          break;
+
+        case 'p':
+          setOverlay({ kind: 'projects', cursor: 0 });
+          setInput('');
+          setMode('insert');
+          inputRef.current?.focus();
+          setFocusedIdx(-1);
+          e.preventDefault();
+          break;
+
+        case 'a':
+          setOverlay({ kind: 'agents', cursor: 0 });
+          setInput('');
+          setMode('insert');
+          inputRef.current?.focus();
+          setFocusedIdx(-1);
+          e.preventDefault();
+          break;
+
+        case 't':
+          navigate({ to: '/' });
+          e.preventDefault();
+          break;
+
+        case '-': {
+          if (currentView.type === 'chat') {
+            navigate({ to: '/' });
+          } else if (
+            currentView.type === 'project-chat' ||
+            currentView.type === 'agent-session'
+          ) {
+            setView({ type: 'chat' });
+          }
+          setFocusedIdx(-1);
+          e.preventDefault();
+          break;
+        }
+
+        case 'j': {
+          setFocusedIdx((f) =>
+            f < 0 ? 0 : Math.min(f + 1, blocks.length - 1),
+          );
+          e.preventDefault();
+          break;
+        }
+
+        case 'k': {
+          setFocusedIdx((f) =>
+            f < 0 ? blocks.length - 1 : Math.max(f - 1, 0),
+          );
+          e.preventDefault();
+          break;
+        }
+
+        case 'y': {
+          if (currentFocused >= 0 && blocks[currentFocused]) {
+            const text = navBlockText(blocks[currentFocused]);
+            if (text) {
+              const quoted = text
+                .split('\n')
+                .map((line) => `> ${line}`)
+                .join('\n');
+              setInput(`${quoted}\n`);
+            }
+          }
+          e.preventDefault();
+          break;
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [navigate]);
+
+  // ── Input change ──────────────────────────────────────────────────────────
+  function handleInputChange(e: React.ChangeEvent<HTMLTextAreaElement>) {
+    const value = e.target.value;
+    setInput(value);
+
+    const currentOverlay = overlayRef.current;
+
+    // When a list picker is open, update resets cursor; no mention detection
+    if (
+      currentOverlay?.kind === 'projects' ||
+      currentOverlay?.kind === 'agents'
+    ) {
+      setOverlay((ov) => (ov ? { ...ov, cursor: 0 } : ov));
+      return;
+    }
+    if (currentOverlay?.kind === 'projects-create') return;
+
+    // Mention detection
+    const cursor = e.target.selectionStart ?? value.length;
+    const before = value.slice(0, cursor);
+    const match = before.match(/@(\w*)$/);
+    if (match) {
+      const atStart = cursor - match[0].length;
+      const query = match[1];
+      setOverlay((prev) => ({
+        kind: 'mention',
+        atStart,
+        query,
+        cursor:
+          prev?.kind === 'mention' && prev.query === query ? prev.cursor : 0,
+      }));
+    } else {
+      setOverlay((prev) => (prev?.kind === 'mention' ? null : prev));
+    }
+  }
+
+  // ── Input keydown ─────────────────────────────────────────────────────────
+  function handleInputKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // Projects picker
+    if (overlay?.kind === 'projects') {
+      const filtered = pickerItems as Project[];
+      const maxCursor = filtered.length; // filtered.length == "+ new project" row
+
+      if (e.key === 'ArrowDown') {
+        setOverlay((ov) =>
+          ov?.kind === 'projects'
+            ? { ...ov, cursor: Math.min(ov.cursor + 1, maxCursor) }
+            : ov,
+        );
+        e.preventDefault();
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        setOverlay((ov) =>
+          ov?.kind === 'projects'
+            ? { ...ov, cursor: Math.max(ov.cursor - 1, 0) }
+            : ov,
+        );
+        e.preventDefault();
+        return;
+      }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        const cur = overlay.cursor;
+        if (cur < filtered.length) {
+          const p = filtered[cur];
+          setView({
+            type: 'project-chat',
+            projectId: p.id,
+            projectName: p.name,
+          });
+          setFocusedIdx(-1);
+          closePicker();
+        } else {
+          // "+ new project" row
+          setOverlay({ kind: 'projects-create' });
+          setInput('');
+        }
+        e.preventDefault();
+        return;
+      }
+      return;
+    }
+
+    // Agents picker
+    if (overlay?.kind === 'agents') {
+      const filtered = pickerItems as AgentInfo[];
+      if (e.key === 'ArrowDown') {
+        setOverlay((ov) =>
+          ov?.kind === 'agents'
+            ? {
+                ...ov,
+                cursor: Math.min(
+                  ov.cursor + 1,
+                  Math.max(filtered.length - 1, 0),
+                ),
+              }
+            : ov,
+        );
+        e.preventDefault();
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        setOverlay((ov) =>
+          ov?.kind === 'agents'
+            ? { ...ov, cursor: Math.max(ov.cursor - 1, 0) }
+            : ov,
+        );
+        e.preventDefault();
+        return;
+      }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        const ag = filtered[overlay.cursor];
+        if (ag) {
+          setView({ type: 'agent-session', agentName: ag.name });
+          setSessionData(null);
+          setFocusedIdx(-1);
+          closePicker();
+        }
+        e.preventDefault();
+        return;
+      }
+      return;
+    }
+
+    // Projects create mode
+    if (overlay?.kind === 'projects-create') {
+      if (e.key === 'Enter' && !e.shiftKey) {
+        if (input.trim()) {
+          const name = input.trim();
+          createProjectFn({ data: { teamId, name } }).then((p) => {
+            setProjects((prev) => [...prev, p]);
+          });
+          closePicker();
+        }
+        e.preventDefault();
+        return;
+      }
+      return;
+    }
+
+    // Mention picker
+    if (overlay?.kind === 'mention') {
+      const filtered = mentionFilteredAgents;
+      if (e.key === 'ArrowDown') {
+        setOverlay((ov) =>
+          ov?.kind === 'mention'
+            ? {
+                ...ov,
+                cursor: Math.min(
+                  ov.cursor + 1,
+                  Math.max(filtered.length - 1, 0),
+                ),
+              }
+            : ov,
+        );
+        e.preventDefault();
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        setOverlay((ov) =>
+          ov?.kind === 'mention'
+            ? { ...ov, cursor: Math.max(ov.cursor - 1, 0) }
+            : ov,
+        );
+        e.preventDefault();
+        return;
+      }
+      if (e.key === 'Enter' && !e.shiftKey) {
+        const selected = filtered[overlay.cursor];
+        if (selected) insertMention(selected.name, overlay.atStart);
+        setOverlay(null);
+        e.preventDefault();
+        return;
+      }
+    }
+
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  }
+
+  const workingAgents = agents.filter((a) => a.status === 'working');
+  const isSending = sending || projectSending;
+  const inputDisabled = isSending || view.type === 'agent-session';
+
+  const inputPlaceholder =
+    overlay?.kind === 'projects-create'
+      ? 'project name...'
+      : overlay?.kind === 'projects' || overlay?.kind === 'agents'
+        ? 'filter...'
+        : undefined;
+
   return (
-    <SidebarProvider>
-      <Sidebar>
-        <SidebarContent>
-          {/* Breadcrumb */}
-          <div className="px-4 py-3">
-            <Breadcrumb>
-              <BreadcrumbList>
-                <BreadcrumbItem>
-                  <BreadcrumbLink asChild>
-                    <Link to="/">teams</Link>
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
-                <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbPage>{teamId}</BreadcrumbPage>
-                </BreadcrumbItem>
-              </BreadcrumbList>
-            </Breadcrumb>
-          </div>
-
-          <Separator />
-
-          {/* Agents */}
-          <SidebarGroup>
-            <SidebarGroupLabel>Agents</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {/* Team chat nav item */}
-                <SidebarMenuItem>
-                  <SidebarMenuButton
-                    isActive={selectedAgent === null}
-                    onClick={() => setSelectedAgent(null)}
-                    className="font-mono text-sm"
-                  >
-                    team chat
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-
-                {agents.map((agent) => (
-                  <SidebarMenuItem key={agent.name}>
-                    <SidebarMenuButton
-                      isActive={selectedAgent === agent.name}
-                      onClick={() => setSelectedAgent(agent.name)}
-                      className="h-auto py-2 flex-col items-start gap-0.5"
-                    >
-                      <div className="flex items-center gap-2 w-full">
-                        <AgentStatusDot status={agent.status} />
-                        <span className="font-mono text-sm truncate">
-                          {agent.name}
-                        </span>
-                        {agent.isLead && (
-                          <Badge
-                            variant="secondary"
-                            className="ml-auto text-xs py-0 shrink-0"
-                          >
-                            lead
-                          </Badge>
-                        )}
-                      </div>
-                      {agent.statusText && (
-                        <span className="text-xs text-muted-foreground pl-4 truncate w-full">
-                          {agent.statusText}
-                        </span>
-                      )}
-                    </SidebarMenuButton>
-                  </SidebarMenuItem>
-                ))}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-
-          <Separator />
-
-          {/* Projects */}
-          <SidebarGroup>
-            <SidebarGroupLabel>Projects</SidebarGroupLabel>
-            <SidebarGroupContent>
-              <SidebarMenu>
-                {initialData.projects.length === 0 ? (
-                  <p className="px-2 py-1 text-xs text-muted-foreground font-mono">
-                    No open projects
-                  </p>
-                ) : (
-                  initialData.projects.map((project) => (
-                    <SidebarMenuItem key={project.id}>
-                      <SidebarMenuButton className="font-mono text-sm">
-                        {project.name}
-                      </SidebarMenuButton>
-                    </SidebarMenuItem>
-                  ))
-                )}
-              </SidebarMenu>
-            </SidebarGroupContent>
-          </SidebarGroup>
-        </SidebarContent>
-      </Sidebar>
-
-      <SidebarInset>
-        {selectedAgent === null ? (
-          <TeamChatView
-            teamId={teamId}
-            messages={messages}
-            input={input}
-            sending={sending}
+    <div className="flex flex-col h-screen bg-background overflow-hidden font-mono">
+      {/* ── Content area ────────────────────────────────────────────────── */}
+      <div className="flex-1 overflow-y-auto min-h-0 flex flex-col">
+        {view.type === 'chat' && (
+          <ChatView
+            navBlocks={navBlocks}
+            focusedIdx={focusedIdx}
+            onFocusBlock={setFocusedIdx}
             bottomRef={bottomRef}
-            onInputChange={setInput}
-            onSend={handleSend}
-          />
-        ) : (
-          <AgentSessionView
-            agentName={selectedAgent}
-            sessionData={sessionData}
-            sessionBottomRef={sessionBottomRef}
           />
         )}
-      </SidebarInset>
-    </SidebarProvider>
-  );
-}
-
-function TeamChatView({
-  teamId,
-  messages,
-  input,
-  sending,
-  bottomRef,
-  onInputChange,
-  onSend,
-}: {
-  teamId: string;
-  messages: Message[];
-  input: string;
-  sending: boolean;
-  bottomRef: React.RefObject<HTMLDivElement | null>;
-  onInputChange: (v: string) => void;
-  onSend: () => void;
-}) {
-  return (
-    <div className="flex flex-col h-screen">
-      <div className="flex items-center gap-3 px-6 py-4 border-b shrink-0">
-        <h1 className="font-mono font-medium text-sm">{teamId}</h1>
-        <span className="text-muted-foreground text-xs">team chat</span>
+        {view.type === 'project-chat' && (
+          <ChatView
+            navBlocks={navBlocks}
+            focusedIdx={focusedIdx}
+            onFocusBlock={setFocusedIdx}
+            bottomRef={bottomRef}
+            emptyText={`No messages in ${view.projectName} yet.`}
+          />
+        )}
+        {view.type === 'agent-session' && (
+          <AgentSessionView
+            agentName={view.agentName}
+            navBlocks={navBlocks}
+            focusedIdx={focusedIdx}
+            onFocusBlock={setFocusedIdx}
+            bottomRef={bottomRef}
+          />
+        )}
       </div>
 
-      <ScrollArea className="flex-1 px-6">
-        <div className="py-4 flex flex-col gap-3">
-          {messages.length === 0 && (
-            <p className="text-sm text-muted-foreground text-center py-8">
-              Send a message to get started.
-            </p>
-          )}
-          {messages.map((msg) => (
-            <MessageBubble key={msg.id} message={msg} />
+      {/* ── Working agent indicator ─────────────────────────────────────── */}
+      {workingAgents.length > 0 && (
+        <div className="px-4 pt-1.5 pb-0.5 flex flex-col gap-0.5">
+          {workingAgents.map((a) => (
+            <div
+              key={a.name}
+              className="text-xs flex gap-1.5 items-baseline truncate"
+            >
+              <span className="text-secondary shrink-0">{a.name}</span>
+              <span className="text-muted-foreground shrink-0">(c)</span>
+              {a.statusText && (
+                <span className="text-muted-foreground/60 italic truncate">
+                  {a.statusText}...
+                </span>
+              )}
+            </div>
           ))}
-          <div ref={bottomRef} />
         </div>
-      </ScrollArea>
+      )}
 
-      <div className="px-6 py-4 border-t shrink-0">
-        <form
-          className="flex gap-2"
-          onSubmit={(e) => {
-            e.preventDefault();
-            onSend();
-          }}
+      {/* ── Input area ──────────────────────────────────────────────────── */}
+      <div className="shrink-0">
+        <Separator />
+        <div className="px-4 pt-1.5 pb-2">
+          <div className="text-xs mb-1 select-none">
+            {overlay?.kind === 'projects-create' ? (
+              <span>
+                <span className="text-foreground/60">new project</span>
+                <span className="text-muted-foreground/30 ml-2">
+                  esc to cancel
+                </span>
+              </span>
+            ) : (
+              <Breadcrumb view={view} teamId={teamId} />
+            )}
+          </div>
+
+          {/* Inline picker list — sits between breadcrumb and prompt */}
+          {showInlinePicker && overlay && (
+            <InlinePicker
+              overlay={overlay}
+              pickerItems={pickerItems}
+              mentionItems={mentionFilteredAgents}
+              onSelectProject={(p) => {
+                setView({
+                  type: 'project-chat',
+                  projectId: p.id,
+                  projectName: p.name,
+                });
+                setFocusedIdx(-1);
+                closePicker();
+              }}
+              onSelectAgent={(ag) => {
+                setView({ type: 'agent-session', agentName: ag.name });
+                setSessionData(null);
+                setFocusedIdx(-1);
+                closePicker();
+              }}
+              onSelectMention={(agent) => {
+                if (overlay?.kind === 'mention')
+                  insertMention(agent.name, overlay.atStart);
+                setOverlay(null);
+                inputRef.current?.focus();
+              }}
+              onCreateProject={() => {
+                setOverlay({ kind: 'projects-create' });
+                setInput('');
+              }}
+            />
+          )}
+
+          <div className="flex items-start gap-1.5">
+            <span className="text-muted-foreground/30 text-sm shrink-0 mt-px select-none leading-relaxed">
+              ❯❯⎽
+            </span>
+            <textarea
+              ref={inputRef}
+              value={input}
+              onChange={handleInputChange}
+              onFocus={() => setMode('insert')}
+              onBlur={() => setMode('normal')}
+              onKeyDown={handleInputKeyDown}
+              disabled={inputDisabled}
+              placeholder={inputDisabled ? '' : inputPlaceholder}
+              rows={1}
+              className={cn(
+                'flex-1 bg-transparent border-none resize-none outline-none text-sm leading-relaxed',
+                'text-foreground placeholder:text-muted-foreground/40 overflow-hidden',
+                inputDisabled && 'opacity-40 cursor-default',
+              )}
+            />
+          </div>
+        </div>
+      </div>
+
+      <Separator />
+
+      {/* ── Status bar ─────────────────────────────────────────────────── */}
+      <div className="px-4 py-1 shrink-0 flex items-center gap-1 text-xs">
+        <button
+          type="button"
+          onClick={() => navigate({ to: '/' })}
+          className="text-muted-foreground/50 hover:text-primary hover:underline"
         >
-          <Input
-            value={input}
-            onChange={(e) => onInputChange(e.target.value)}
-            placeholder="Message the team…"
-            disabled={sending}
-            className="font-mono text-sm"
-          />
-          <Button type="submit" disabled={sending || !input.trim()} size="sm">
-            {sending ? 'Waiting…' : 'Send'}
-          </Button>
-        </form>
+          teams
+        </button>
+        <span className="text-muted-foreground/30 ml-0.5">(t)</span>
+        <button
+          type="button"
+          onClick={() => {
+            setOverlay({ kind: 'projects', cursor: 0 });
+            setInput('');
+            setMode('insert');
+            inputRef.current?.focus();
+            setFocusedIdx(-1);
+          }}
+          className="text-primary hover:underline ml-3"
+        >
+          {projects.length} projects
+        </button>
+        <span className="text-muted-foreground ml-0.5">(p)</span>
+        <button
+          type="button"
+          onClick={() => {
+            setOverlay({ kind: 'agents', cursor: 0 });
+            setInput('');
+            setMode('insert');
+            inputRef.current?.focus();
+            setFocusedIdx(-1);
+          }}
+          className="text-primary hover:underline ml-3"
+        >
+          {agents.length} agents
+        </button>
+        <span className="text-muted-foreground ml-0.5">(a)</span>
+        {mode === 'normal' && (
+          <span className="ml-auto text-muted-foreground/50">NORMAL</span>
+        )}
       </div>
     </div>
   );
 }
+
+// ── InlinePicker ───────────────────────────────────────────────────────────
+
+function InlinePicker({
+  overlay,
+  pickerItems,
+  mentionItems,
+  onSelectProject,
+  onSelectAgent,
+  onSelectMention,
+  onCreateProject,
+}: {
+  overlay: OverlayState;
+  pickerItems: Project[] | AgentInfo[];
+  mentionItems: AgentInfo[];
+  onSelectProject: (p: Project) => void;
+  onSelectAgent: (ag: AgentInfo) => void;
+  onSelectMention: (agent: AgentInfo) => void;
+  onCreateProject: () => void;
+}) {
+  const cursor = 'cursor' in overlay ? overlay.cursor : 0;
+
+  if (overlay.kind === 'mention') {
+    return (
+      <div className="border-t border-border/20 -mx-4 mb-2 max-h-40 overflow-y-auto">
+        {(mentionItems as AgentInfo[]).map((agent, i) => (
+          <button
+            key={agent.name}
+            type="button"
+            onClick={() => onSelectMention(agent)}
+            className={cn(
+              'flex items-baseline gap-3 text-left w-full px-4 py-0.5 text-sm font-mono transition-colors',
+              i === cursor
+                ? 'bg-accent text-accent-foreground'
+                : 'hover:bg-accent/40',
+            )}
+          >
+            <span
+              className={cn(
+                agent.status === 'working'
+                  ? 'text-secondary'
+                  : 'text-foreground',
+              )}
+            >
+              @{agent.name}
+            </span>
+            {agent.status === 'working' && (
+              <span className="text-xs text-secondary/70">working</span>
+            )}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  const isProjects = overlay.kind === 'projects';
+  const items = pickerItems as (Project | AgentInfo)[];
+  const createHighlighted = isProjects && cursor === items.length;
+
+  return (
+    <div className="border-t border-border/20 -mx-4 mb-2 max-h-48 overflow-y-auto">
+      {items.length === 0 && (
+        <div className="px-4 py-0.5 text-sm text-muted-foreground/50 italic font-mono">
+          (no matches)
+        </div>
+      )}
+      {items.map((item, i) => {
+        const isCursor = i === cursor && !createHighlighted;
+        if (isProjects) {
+          const p = item as Project;
+          return (
+            <button
+              key={p.id}
+              type="button"
+              onClick={() => onSelectProject(p)}
+              className={cn(
+                'flex items-baseline justify-between text-left w-full px-4 py-0.5 text-sm font-mono transition-colors',
+                isCursor
+                  ? 'bg-accent text-accent-foreground'
+                  : 'hover:bg-accent/40',
+              )}
+            >
+              <span className="text-foreground">{p.name}</span>
+              <span className="text-xs ml-4 text-muted-foreground/60">
+                {p.status}
+              </span>
+            </button>
+          );
+        }
+        const ag = item as AgentInfo;
+        return (
+          <button
+            key={ag.name}
+            type="button"
+            onClick={() => onSelectAgent(ag)}
+            className={cn(
+              'flex items-baseline justify-between text-left w-full px-4 py-0.5 text-sm font-mono transition-colors',
+              isCursor
+                ? 'bg-accent text-accent-foreground'
+                : 'hover:bg-accent/40',
+            )}
+          >
+            <span
+              className={cn(
+                ag.status === 'working' ? 'text-secondary' : 'text-foreground',
+              )}
+            >
+              {ag.name}
+            </span>
+            <span
+              className={cn(
+                'text-xs ml-4',
+                ag.status === 'working'
+                  ? 'text-secondary/70'
+                  : 'text-muted-foreground/60',
+              )}
+            >
+              {ag.status === 'working'
+                ? `working — ${ag.statusText ?? '...'}`
+                : 'idle'}
+            </span>
+          </button>
+        );
+      })}
+      {isProjects && (
+        <button
+          type="button"
+          onClick={onCreateProject}
+          className={cn(
+            'flex items-center gap-1 text-left w-full px-4 py-0.5 text-sm font-mono transition-colors border-t border-border/20',
+            createHighlighted
+              ? 'bg-accent text-accent-foreground'
+              : 'text-muted-foreground/50 hover:text-primary hover:bg-accent/40',
+          )}
+        >
+          + new project
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── ChatView ───────────────────────────────────────────────────────────────
+
+function ChatView({
+  navBlocks,
+  focusedIdx,
+  onFocusBlock,
+  bottomRef,
+  emptyText = 'Send a message to get started.',
+}: {
+  navBlocks: NavBlock[];
+  focusedIdx: number;
+  onFocusBlock: (i: number) => void;
+  bottomRef: React.RefObject<HTMLDivElement | null>;
+  emptyText?: string;
+}) {
+  type Group = {
+    sender: string;
+    isUser: boolean;
+    blocks: { b: NavBlock; idx: number }[];
+  };
+  const groups: Group[] = [];
+  for (let i = 0; i < navBlocks.length; i++) {
+    const nb = navBlocks[i];
+    if (nb.kind !== 'chat') continue;
+    const last = groups[groups.length - 1];
+    if (last && last.sender === nb.sender) {
+      last.blocks.push({ b: nb, idx: i });
+    } else {
+      groups.push({
+        sender: nb.sender,
+        isUser: nb.isUser,
+        blocks: [{ b: nb, idx: i }],
+      });
+    }
+  }
+
+  return (
+    <div className="px-4 py-4 flex flex-col gap-4 mt-auto">
+      {navBlocks.length === 0 && (
+        <p className="text-sm text-muted-foreground py-8 text-center">
+          {emptyText}
+        </p>
+      )}
+      {groups.map((group) => (
+        <div key={group.blocks[0].b.id} className="flex flex-col gap-0.5">
+          <span
+            className={cn(
+              'text-sm font-bold mb-1',
+              group.isUser ? 'text-primary' : 'text-secondary',
+            )}
+          >
+            {group.sender}
+          </span>
+          {group.blocks.map(({ b, idx }) => {
+            if (b.kind !== 'chat') return null;
+            const isFocused = idx === focusedIdx;
+            return (
+              <button
+                key={b.id}
+                type="button"
+                onClick={() => onFocusBlock(idx)}
+                className={cn(
+                  'text-left w-full py-0.5 pl-2 -ml-2 rounded-sm transition-colors',
+                  isFocused ? 'bg-primary/10' : 'hover:bg-accent/20',
+                )}
+              >
+                <div className="prose prose-sm dark:prose-invert max-w-none text-sm text-foreground">
+                  <Markdown components={markdownComponents}>
+                    {b.content}
+                  </Markdown>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      ))}
+      <div ref={bottomRef} />
+    </div>
+  );
+}
+
+// ── AgentSessionView ───────────────────────────────────────────────────────
 
 function AgentSessionView({
   agentName,
-  sessionData,
-  sessionBottomRef,
+  navBlocks,
+  focusedIdx,
+  onFocusBlock,
+  bottomRef,
 }: {
   agentName: string;
-  sessionData: SessionData | null;
-  sessionBottomRef: React.RefObject<HTMLDivElement | null>;
+  navBlocks: NavBlock[];
+  focusedIdx: number;
+  onFocusBlock: (i: number) => void;
+  bottomRef: React.RefObject<HTMLDivElement | null>;
 }) {
-  return (
-    <div className="flex flex-col h-screen">
-      <div className="flex items-center gap-3 px-6 py-4 border-b shrink-0">
-        <h1 className="font-mono font-medium text-sm">{agentName}</h1>
-        <span className="text-muted-foreground text-xs">session history</span>
-        {sessionData?.status === 'working' && (
-          <span className="ml-auto text-xs text-muted-foreground font-mono animate-pulse truncate max-w-[60%]">
-            {sessionData.statusText ?? 'working…'}
-          </span>
-        )}
-      </div>
-
-      <ScrollArea className="flex-1 px-6">
-        <div className="py-4 flex flex-col gap-4">
-          {!sessionData || sessionData.messages.length === 0 ? (
-            <p className="text-sm text-muted-foreground text-center py-8">
-              No session history yet.
-            </p>
-          ) : (
-            sessionData.messages.map((msg) => (
-              <SessionTurn key={msg.uuid} msg={msg} />
-            ))
-          )}
-          <div ref={sessionBottomRef} />
-        </div>
-      </ScrollArea>
-    </div>
-  );
-}
-
-type ContentBlock =
-  | { type: 'text'; text: string }
-  | { type: 'thinking'; thinking: string }
-  | { type: 'tool_use'; name: string; input: unknown }
-  | { type: 'tool_result'; content: unknown }
-  | { type: string; [key: string]: unknown };
-
-function SessionTurn({ msg }: { msg: AgentSessionMessage }) {
-  if (msg.type === 'system') return null;
-
-  const raw = msg.message;
-  const role = (raw?.role as string | undefined) ?? msg.type;
-  const isUser = role === 'user';
-
-  const content = raw?.content;
-  const blocks: ContentBlock[] = (() => {
-    if (!content) return [];
-    if (typeof content === 'string') return [{ type: 'text', text: content }];
-    if (Array.isArray(content)) return content as ContentBlock[];
-    return [];
-  })();
-
-  // Skip tool-result-only user messages — these are just API round-trips, not chat
-  if (
-    isUser &&
-    blocks.length > 0 &&
-    blocks.every((b) => b.type === 'tool_result')
-  ) {
-    return null;
+  type BlockGroup = { blocks: { b: NavBlock; idx: number }[] };
+  const groups: BlockGroup[] = [{ blocks: [] }];
+  for (let i = 0; i < navBlocks.length; i++) {
+    const nb = navBlocks[i];
+    if (nb.kind !== 'session') continue;
+    groups[0].blocks.push({ b: nb, idx: i });
   }
 
-  if (blocks.length === 0) return null;
-
   return (
-    <div className="flex flex-col gap-1">
-      <span
-        className={cn(
-          'text-xs font-mono font-bold',
-          isUser ? 'text-primary' : 'text-secondary',
-        )}
-      >
-        {isUser ? 'you' : role}
-      </span>
-      <div className="flex flex-col gap-1">
-        {blocks.map((block, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: blocks within a message are stable and have no unique IDs
-          <SessionBlock key={i} block={block} isUser={isUser} />
-        ))}
-      </div>
+    <div className="px-4 py-4 flex flex-col gap-4 mt-auto">
+      {navBlocks.length === 0 && (
+        <p className="text-sm text-muted-foreground py-8 text-center">
+          No session history for {agentName} yet.
+        </p>
+      )}
+      {groups[0].blocks.length > 0 && (
+        <div className="flex flex-col gap-0.5">
+          <span className="text-sm font-bold mb-1 text-secondary">
+            {agentName}
+          </span>
+          {groups[0].blocks.map(({ b, idx }) => {
+            const isFocused = idx === focusedIdx;
+            if (b.kind !== 'session') return null;
+            return (
+              <button
+                key={b.id}
+                type="button"
+                onClick={() => onFocusBlock(idx)}
+                className={cn(
+                  'text-left w-full py-0.5 pl-2 -ml-2 rounded-sm transition-colors',
+                  isFocused ? 'bg-primary/10' : 'hover:bg-accent/20',
+                )}
+              >
+                <SessionBlockContent block={b.block} />
+              </button>
+            );
+          })}
+        </div>
+      )}
+      <div ref={bottomRef} />
     </div>
   );
 }
 
-function SessionBlock({
-  block,
-  isUser,
-}: {
-  block: ContentBlock;
-  isUser: boolean;
-}) {
+function SessionBlockContent({ block }: { block: ContentBlock }) {
   if (block.type === 'text') {
-    const text = block as { type: 'text'; text: string };
+    const b = block as { type: 'text'; text: string };
     return (
       <div className="prose prose-sm dark:prose-invert max-w-none text-sm text-foreground">
-        <Markdown>{text.text}</Markdown>
+        <Markdown components={markdownComponents}>{b.text}</Markdown>
       </div>
     );
   }
-
   if (block.type === 'thinking') {
-    const thinking = block as { type: 'thinking'; thinking: string };
+    const b = block as { type: 'thinking'; thinking: string };
     return (
-      <details className="text-xs text-muted-foreground/50 font-mono">
+      <details className="text-xs text-muted-foreground/50">
         <summary className="cursor-pointer select-none">thinking</summary>
-        <p className="mt-1 whitespace-pre-wrap">{thinking.thinking}</p>
+        <p className="mt-1 whitespace-pre-wrap">{b.thinking}</p>
       </details>
     );
   }
-
   if (block.type === 'tool_use') {
-    const tool = block as { type: 'tool_use'; name: string; input: unknown };
+    const b = block as { type: 'tool_use'; name: string; input: unknown };
     return (
-      <details className="text-xs text-muted-foreground/50 font-mono">
-        <summary className="cursor-pointer select-none">{tool.name}</summary>
+      <details className="text-xs text-muted-foreground/50">
+        <summary className="cursor-pointer select-none">{b.name}</summary>
         <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-all">
-          {JSON.stringify(tool.input, null, 2)}
+          {JSON.stringify(b.input, null, 2)}
         </pre>
       </details>
     );
   }
-
-  // tool_result blocks are filtered at the turn level; skip here
   return null;
-}
-
-function MessageBubble({ message }: { message: Message }) {
-  const isUser = message.sender === 'user';
-  return (
-    <div className="flex flex-col gap-0.5">
-      <span
-        className={cn(
-          'text-xs font-mono font-bold',
-          isUser ? 'text-primary' : 'text-secondary',
-        )}
-      >
-        {isUser ? 'you' : message.sender}
-      </span>
-      <div className="prose prose-sm dark:prose-invert max-w-none text-sm text-foreground">
-        <Markdown>{message.content}</Markdown>
-      </div>
-    </div>
-  );
 }

--- a/src/server/team-data.ts
+++ b/src/server/team-data.ts
@@ -139,6 +139,7 @@ export async function runConversationLoop({
   cwd,
   teamMemberMeta,
   projectBranch,
+  projectId,
   runAgentFn,
 }: {
   db: import('~/db/index').Database;
@@ -147,28 +148,45 @@ export async function runConversationLoop({
   cwd: string;
   teamMemberMeta: Array<{ name: string; description: string; isLead: boolean }>;
   projectBranch?: string;
+  /** When set, sessions and messages are scoped to this project rather than the team. */
+  projectId?: string;
   /** Injectable for tests — defaults to the real runAgent when omitted. */
   runAgentFn?: RunAgentFn;
 }): Promise<void> {
   const { join } = await import('node:path');
-  const { insertMessage, getTeamMessages } = await import('~/db/messages');
+  const { insertMessage, getTeamMessages, getProjectMessages } = await import(
+    '~/db/messages'
+  );
   const { getSession, setSessionSdkId, upsertSession } = await import(
     '~/db/sessions'
   );
+
+  /** Fetch the most recent messages in the right scope (team or project). */
+  const getRecentMessages = () =>
+    projectId
+      ? getProjectMessages(db, projectId).slice(-20)
+      : getTeamMessages(db, teamId).slice(-20);
 
   // Build the default runAgent wrapper that handles DB status persistence.
   // Tests override this entirely via runAgentFn.
   const { runAgent } = await import('./agent-runner');
   const defaultRunAgent: RunAgentFn = (opts) => {
-    const existing = getSession(db, teamId, opts.agentName);
+    const existing = getSession(db, teamId, opts.agentName, projectId);
     return runAgent({
       ...opts,
       existingSdkSessionId: existing?.sdk_session_id ?? undefined,
       onStatus: (status, statusText) => {
-        upsertSession(db, teamId, opts.agentName, status, statusText);
+        upsertSession(
+          db,
+          teamId,
+          opts.agentName,
+          status,
+          statusText,
+          projectId,
+        );
       },
       onSessionId: (sessionId) => {
-        setSessionSdkId(db, teamId, opts.agentName, sessionId);
+        setSessionSdkId(db, teamId, opts.agentName, sessionId, projectId);
       },
     });
   };
@@ -188,7 +206,7 @@ export async function runConversationLoop({
   let totalTurns = 0;
 
   while (totalTurns < MAX_AGENT_TURNS) {
-    const recentMessages = getTeamMessages(db, teamId).slice(-20);
+    const recentMessages = getRecentMessages();
     const lastMessage = recentMessages[recentMessages.length - 1];
     if (!lastMessage) break;
 
@@ -241,7 +259,7 @@ export async function runConversationLoop({
       totalTurns++;
       respondedAgents.add(agentName);
 
-      const chatContext = getTeamMessages(db, teamId).slice(-20);
+      const chatContext = getRecentMessages();
       const triggerContent = chatContext[chatContext.length - 1]?.content ?? '';
 
       let responseText: string;
@@ -272,7 +290,7 @@ export async function runConversationLoop({
       } catch (err) {
         console.error(`[nightshift] agent ${agentName} failed:`, err);
         // Force the session idle in case runAgent's finally block never ran
-        upsertSession(db, teamId, agentName, 'idle', undefined);
+        upsertSession(db, teamId, agentName, 'idle', undefined, projectId);
         break;
       }
 
@@ -282,7 +300,7 @@ export async function runConversationLoop({
         teamId,
         agentName,
         responseText,
-        undefined,
+        projectId,
         mentionedAgents,
       );
 
@@ -372,11 +390,69 @@ export const sendTeamMessage = createServerFn({ method: 'POST' })
   });
 
 export const getAgentStatuses = createServerFn({ method: 'GET' })
-  .inputValidator((data: { teamId: string }) => data)
+  .inputValidator((data: { teamId: string; projectId?: string }) => data)
   .handler(async ({ data }) => {
     const { getSessionsByTeam } = await import('~/db/sessions');
     const db = await getDb();
-    return getSessionsByTeam(db, data.teamId);
+    return getSessionsByTeam(db, data.teamId, data.projectId);
+  });
+
+export const getProjectMessages = createServerFn({ method: 'GET' })
+  .inputValidator((data: { teamId: string; projectId: string }) => data)
+  .handler(async ({ data }) => {
+    const { getProjectMessages: getProjectMsgs } = await import(
+      '~/db/messages'
+    );
+    const db = await getDb();
+    return getProjectMsgs(db, data.projectId);
+  });
+
+export const sendProjectMessage = createServerFn({ method: 'POST' })
+  .inputValidator(
+    (data: { teamId: string; projectId: string; content: string }) => data,
+  )
+  .handler(async ({ data }) => {
+    const { insertMessage } = await import('~/db/messages');
+    const { resetStuckSessions } = await import('~/db/sessions');
+    const { getProjectsByTeam } = await import('~/db/projects');
+
+    const cwd = await resolveCwd();
+    const [db, teams] = await Promise.all([getDb(), readTeams(cwd)]);
+
+    resetStuckSessions(db, data.teamId, data.projectId);
+
+    const team = teams.find((t) => t.name === data.teamId);
+    const leadName = team?.lead ?? 'project-lead';
+    const allAgentNames = team ? orderedMembers(team) : [leadName];
+
+    const userMentions = parseMentions(data.content, allAgentNames);
+    insertMessage(
+      db,
+      data.teamId,
+      'user',
+      data.content,
+      data.projectId,
+      userMentions,
+    );
+
+    const project = getProjectsByTeam(db, data.teamId).find(
+      (p) => p.id === data.projectId,
+    );
+    const teamMemberMeta = team
+      ? await readTeamMemberMeta(cwd, team)
+      : [{ name: leadName, description: '', isLead: true }];
+
+    await runConversationLoop({
+      db,
+      teamId: data.teamId,
+      team: team ?? { name: data.teamId, lead: leadName, members: [] },
+      cwd,
+      teamMemberMeta,
+      projectBranch: project?.branch,
+      projectId: data.projectId,
+    });
+
+    return { ok: true };
   });
 
 export const getAgentSession = createServerFn({ method: 'GET' })
@@ -408,4 +484,17 @@ export const getAgentSession = createServerFn({ method: 'GET' })
       status: session.status,
       statusText: session.status_text,
     };
+  });
+
+export const createNewProject = createServerFn({ method: 'POST' })
+  .inputValidator((data: { teamId: string; name: string }) => data)
+  .handler(async ({ data }) => {
+    const { insertProject } = await import('~/db/projects');
+    const db = await getDb();
+    const branch =
+      data.name
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9-]/g, '') || 'new-project';
+    return insertProject(db, data.name, data.teamId, branch);
   });

--- a/src/server/teams.ts
+++ b/src/server/teams.ts
@@ -66,3 +66,16 @@ export async function resolveCwd(): Promise<string> {
 export const listTeams = createServerFn({ method: 'GET' }).handler(async () =>
   readTeams(await resolveCwd()),
 );
+
+export const createTeam = createServerFn({ method: 'POST' })
+  .inputValidator((data: { name: string }) => data)
+  .handler(async ({ data }) => {
+    const { writeFile, mkdir } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+    const cwd = await resolveCwd();
+    const teamDir = join(cwd, '.nightshift', 'teams', data.name);
+    await mkdir(teamDir, { recursive: true });
+    const toml = `name = "${data.name}"\nlead = ""\nmembers = []\n`;
+    await writeFile(join(teamDir, 'team.toml'), toml, 'utf8');
+    return { name: data.name, lead: '', members: [] } satisfies TeamMeta;
+  });

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,0 +1,56 @@
+// Preload (bunfig.toml) — runs before every test file.
+// Manually installs happy-dom globals since bun 1.3.8 does not support
+// the `environment` key in bunfig.toml (added in a later release).
+// Uses GlobalWindow (not Window) so built-ins like SyntaxError are present
+// on the window object — required by happy-dom's querySelectorAll internals.
+import { GlobalWindow } from 'happy-dom';
+
+const happyWindow = new GlobalWindow({ url: 'http://localhost:3000/' });
+
+// biome-ignore lint/suspicious/noExplicitAny: DOM polyfill assignment
+const g = globalThis as any;
+// biome-ignore lint/suspicious/noExplicitAny: DOM polyfill assignment
+const w = happyWindow as any;
+
+// Core
+g.window = happyWindow;
+g.document = happyWindow.document;
+g.navigator = happyWindow.navigator;
+g.location = happyWindow.location;
+g.history = happyWindow.history;
+g.screen = happyWindow.screen;
+g.getComputedStyle = w.getComputedStyle?.bind(happyWindow);
+g.requestAnimationFrame = w.requestAnimationFrame?.bind(happyWindow);
+g.cancelAnimationFrame = w.cancelAnimationFrame?.bind(happyWindow);
+
+// DOM constructors
+g.Event = w.Event;
+g.CustomEvent = w.CustomEvent;
+g.EventTarget = w.EventTarget;
+g.Node = w.Node;
+g.Element = w.Element;
+g.HTMLElement = w.HTMLElement;
+g.HTMLInputElement = w.HTMLInputElement;
+g.HTMLTextAreaElement = w.HTMLTextAreaElement;
+g.HTMLButtonElement = w.HTMLButtonElement;
+g.HTMLSelectElement = w.HTMLSelectElement;
+g.HTMLFormElement = w.HTMLFormElement;
+g.MutationObserver = w.MutationObserver;
+g.IntersectionObserver = w.IntersectionObserver;
+g.ResizeObserver = w.ResizeObserver;
+g.Range = w.Range;
+g.Text = w.Text;
+g.Comment = w.Comment;
+g.DocumentFragment = w.DocumentFragment;
+g.KeyboardEvent = w.KeyboardEvent;
+g.MouseEvent = w.MouseEvent;
+g.PointerEvent = w.PointerEvent;
+g.FocusEvent = w.FocusEvent;
+g.InputEvent = w.InputEvent;
+g.UIEvent = w.UIEvent;
+g.WheelEvent = w.WheelEvent;
+g.Selection = w.Selection;
+g.DOMException = w.DOMException;
+g.DOMParser = w.DOMParser;
+g.CSSStyleDeclaration = w.CSSStyleDeclaration;
+g.SVGElement = w.SVGElement;


### PR DESCRIPTION
## Summary

- **Fix: input mode stuck after send** — textarea becomes disabled during send, loses focus, but mode stayed `'insert'` forever. Added `onBlur={() => setMode('normal')}` so mode resets and the user can type again after send completes.
- **Fix: breadcrumb rendering** — project-chat now shows `~/team (project)` (project name in secondary color) instead of `~/team/project`; agent-session path is fully `text-primary`.
- **New: CommandPicker component** — self-contained keyboard/mouse picker with filtering, cursor nav, and an inline create flow.
- **New: RTL test infrastructure** — set up `@testing-library/react` + `@testing-library/user-event` with happy-dom's `GlobalWindow` (bun 1.3.8 workaround; `bunfig.toml` `environment` key is not supported in this version).
- **30 new tests** — full CommandPicker coverage (rendering, filtering, keyboard/mouse nav, create flow) + `$teamId` breadcrumb and input-mode regression tests.

## Test plan

- [ ] `bun test` — all 132 tests pass
- [ ] `bun lint` — no errors
- [ ] `bun typecheck` — no type errors
- [ ] Manual: open a team chat, send a message, verify textarea is usable after send completes
- [ ] Manual: switch to project-chat view, verify breadcrumb shows `~/team (project)` with correct colors
- [ ] Manual: switch to agent-session view, verify breadcrumb shows `~/team/agent` all in primary color

🤖 Generated with [Claude Code](https://claude.com/claude-code)