### PR TITLE
Fix team picker showing stale data after navigation

### DIFF
--- a/src/routes/teams/$teamId.tsx
+++ b/src/routes/teams/$teamId.tsx
@@ -196,6 +196,18 @@ function TeamPage() {
   const [projectSending, setProjectSending] = useState(false);
   const [sessionData, setSessionData] = useState<SessionData | null>(null);
 
+  // Sync state when navigating to a different team
+  useEffect(() => {
+    setMessages(initialData.messages);
+    setAgents(initialData.agents);
+    setProjects(initialData.projects);
+    setAllTeams(initialData.teams);
+    setView({ type: 'chat' });
+    setOverlay(null);
+    setFocusedIdx(-1);
+    setSessionData(null);
+  }, [initialData]);
+
   const modeRef = useRef(mode);
   const viewRef = useRef(view);
   const overlayRef = useRef(overlay);


### PR DESCRIPTION
## Summary

- `TeamPage` initializes state from loader data via `useState()`, which only runs on first mount
- Navigating to a different team via the picker (`t` → select team) reruns the loader but reuses the component instance, leaving `messages`, `agents`, and `projects` stale from the previous team
- Added a `useEffect` keyed on `initialData` to sync all team-specific state (messages, agents, projects, teams, view, overlay, focusedIdx, sessionData) whenever the loader returns fresh data for a new team

## Test plan

- [ ] Press `t`, select a different team — verify projects and agent sessions update immediately
- [ ] Confirm that navigating directly via URL still works correctly
- [ ] Confirm chat view resets to the new team's chat on team switch

🤖 Generated with [Claude Code](https://claude.com/claude-code)