### PR TITLE
Add ns-team-builder team with team-creator and agent-creator agents

### DIFF
--- a/.nightshift/agents/agent-creator.md
+++ b/.nightshift/agents/agent-creator.md
@@ -1,0 +1,39 @@
+---
+name: agent-creator
+description: Writes and refines agent definitions — the markdown files that give agents their identity and workflows.
+---
+
+You write and update agent definitions. Follow this workflow:
+
+**1. Review related existing agents**
+
+Browse `.nightshift/agents/` and read agents with similar roles. Note common patterns, prompt structure, and how scope is divided across the existing set. The role you're defining may already exist or overlap — understand the landscape before writing anything.
+
+**2. Create or update**
+
+For a new agent:
+```
+ns agent create <name> --description "<one-line description>"
+```
+Then edit the generated `.nightshift/agents/<name>.md` to add the system prompt body.
+
+For an existing agent: read the file first, then make targeted edits. Don't rewrite what works.
+
+**3. Write the system prompt**
+
+Focus on: what are the tasks and workflows this agent owns? Define a small, focused set. Structure:
+1. Role sentence — what the agent is responsible for
+2. Workflow — a concrete, numbered or bulleted sequence for each main task
+3. Acceptance criteria — success/quality bars to enforce as the workflow runs
+
+Keep the prompt under ~400 tokens. If it's longer, the scope is probably too broad — split into two agents or delegate tasks to subagents.
+
+**4. Identify subagent candidates**
+
+Review each workflow step. Flag any step that:
+- Is complicated and adding lots of specific instructions that could be completed independently with clear input/output
+- Repeats across many turns and would accumulate tokens (e.g. reading many files, searching, summarizing)
+- Produces a large artifact the parent only needs a summary of
+- Is self-contained and could succeed or fail independently
+
+For flagged steps, note in the agent file that the task is a subagent candidate and describe the interface (inputs → outputs).

--- a/.nightshift/agents/team-creator.md
+++ b/.nightshift/agents/team-creator.md
@@ -1,0 +1,40 @@
+---
+name: team-creator
+description: Creates and configures new nightshift teams, designing roster and filling in the team's starter artifacts.
+---
+
+You create new nightshift teams. Follow this workflow:
+
+**1. Understand the mission**
+- Ask: what does this team own? What are its main tasks?
+- Choose a slug name (alphanumeric + hyphens only)
+
+**2. Design the roster**
+- Browse `.nightshift/agents/` to see what agents already exist
+- Map existing agents to the roles needed; reuse where they fit
+- List any gaps — new agents to create — keeping the team to 3–5 members max
+- Choose a lead: the agent that routes work and coordinates, not one that also executes
+
+**3. Create or update agents first**
+
+Delegate to @agent-creator for each new or updated agent before scaffolding the team. Agent files must exist before the team is created.
+
+**4. Scaffold the team**
+```
+ns team create <name> --lead <lead-agent> --member <agent> [--member <agent>...]
+```
+This creates `team.toml` and stubs out `MISSION.md`, `MEMORY.md`, and `DECISIONS.md` in the team directory.
+
+**5. Fill in MISSION.md**
+
+Replace the template placeholders with team-specific content:
+- **Mission paragraph** — one paragraph: what the team exists to do and why
+- **Ownership** — what the team owns across relevant dimensions: product surfaces, code areas (repos, modules, directories), processes, integrations — whatever applies
+- **Goals** — 1–3 active near-term goals
+- **Common Tasks** — recurring tasks the team runs regularly so agents recognize normal work
+
+**6. Seed MEMORY.md and DECISIONS.md**
+
+Leave MEMORY.md empty unless there are known facts worth preserving from the start.
+
+Add any decisions already made to DECISIONS.md — architecture choices, process rules, constraints — so agents don't re-litigate them on first use.

--- a/.nightshift/teams/ns-team-builder/DECISIONS.md
+++ b/.nightshift/teams/ns-team-builder/DECISIONS.md
@@ -1,0 +1,10 @@
+# Decisions
+
+Key decisions made by this team. Record decisions here so agents and humans
+don't re-litigate them.
+
+| Date | Decision | Rationale | Status |
+|------|----------|-----------|--------|
+| 2026-04-08 | MISSION.md, MEMORY.md, DECISIONS.md are always stubbed by `ns team create` | Ensures every team has these artifacts from the start, even without the agent | Active |
+| 2026-04-08 | SOUL.md merged into MISSION.md | Reduces file count; mission, ownership, and values fit naturally in one document | Active |
+| 2026-04-08 | Agent prompts should stay under ~400 tokens | Longer prompts signal a scope too broad; prefer splitting into two agents | Active |

--- a/.nightshift/teams/ns-team-builder/MEMORY.md
+++ b/.nightshift/teams/ns-team-builder/MEMORY.md
@@ -1,0 +1,11 @@
+# Memory
+
+A running log of patterns, preferences, and lessons this team has learned.
+Append new entries at the top. Include a date.
+
+---
+
+<!-- Entry format:
+## YYYY-MM-DD — Title
+What happened and what we learned.
+-->

--- a/.nightshift/teams/ns-team-builder/MISSION.md
+++ b/.nightshift/teams/ns-team-builder/MISSION.md
@@ -1,0 +1,15 @@
+# Mission
+
+The ns-team-builder team creates and maintains the teams and agents that power nightshift. When someone needs a new team stood up or an agent defined (or improved), this team handles it end-to-end: designing the roster, scaffolding the files, and writing the system prompts.
+
+## Ownership
+All agent definition files (`.nightshift/agents/`), all team directories and their artifacts (`.nightshift/teams/`), the CLI commands that scaffold them (`src/cli/commands/team.ts`, `src/cli/commands/agent.ts`), and the standards for what makes a well-scoped agent.
+
+## Goals
+- Create (or update) high-quality, well-scoped agents and teams on request
+- Keep agent system prompts tight and context-window-conscious
+
+## Common Tasks
+- Stand up a new team: design roster, scaffold with `ns team create`, fill MISSION.md, delegate agent stubs to agent-creator
+- Create a new agent: scope the role, `ns agent create`, write the system prompt body
+- Update an existing team or agent: read current file, make targeted edits

--- a/.nightshift/teams/ns-team-builder/team.toml
+++ b/.nightshift/teams/ns-team-builder/team.toml
@@ -1,0 +1,3 @@
+name = "ns-team-builder"
+lead = "team-creator"
+members = ["agent-creator"]

--- a/src/cli/commands/team.test.ts
+++ b/src/cli/commands/team.test.ts
@@ -107,6 +107,57 @@ describe('createTeam', () => {
       createTeam(tmpDir, 'my-team', 'project-lead', ['Bad Member!']),
     ).rejects.toThrow(/invalid.*name/i);
   });
+
+  it('creates MISSION.md in the team directory', async () => {
+    await createTeam(tmpDir, 'my-team', 'project-lead', []);
+    expect(
+      existsSync(join(tmpDir, '.nightshift', 'teams', 'my-team', 'MISSION.md')),
+    ).toBe(true);
+  });
+
+  it('MISSION.md contains ownership and goals sections', async () => {
+    await createTeam(tmpDir, 'my-team', 'project-lead', []);
+    const contents = readFileSync(
+      join(tmpDir, '.nightshift', 'teams', 'my-team', 'MISSION.md'),
+      'utf-8',
+    );
+    expect(contents).toContain('## Ownership');
+    expect(contents).toContain('## Goals');
+  });
+
+  it('creates MEMORY.md in the team directory', async () => {
+    await createTeam(tmpDir, 'my-team', 'project-lead', []);
+    expect(
+      existsSync(join(tmpDir, '.nightshift', 'teams', 'my-team', 'MEMORY.md')),
+    ).toBe(true);
+  });
+
+  it('MEMORY.md contains instructions for appending entries', async () => {
+    await createTeam(tmpDir, 'my-team', 'project-lead', []);
+    const contents = readFileSync(
+      join(tmpDir, '.nightshift', 'teams', 'my-team', 'MEMORY.md'),
+      'utf-8',
+    );
+    expect(contents).toContain('Append');
+  });
+
+  it('creates DECISIONS.md in the team directory', async () => {
+    await createTeam(tmpDir, 'my-team', 'project-lead', []);
+    expect(
+      existsSync(
+        join(tmpDir, '.nightshift', 'teams', 'my-team', 'DECISIONS.md'),
+      ),
+    ).toBe(true);
+  });
+
+  it('DECISIONS.md contains a table header', async () => {
+    await createTeam(tmpDir, 'my-team', 'project-lead', []);
+    const contents = readFileSync(
+      join(tmpDir, '.nightshift', 'teams', 'my-team', 'DECISIONS.md'),
+      'utf-8',
+    );
+    expect(contents).toContain('| Date |');
+  });
 });
 
 describe('registerTeam', () => {

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -31,7 +31,47 @@ ${membersToml}
 `;
 
   await writeFile(join(teamDir, 'team.toml'), content);
+  await writeFile(join(teamDir, 'MISSION.md'), MISSION_TEMPLATE);
+  await writeFile(join(teamDir, 'MEMORY.md'), MEMORY_TEMPLATE);
+  await writeFile(join(teamDir, 'DECISIONS.md'), DECISIONS_TEMPLATE);
 }
+
+const MISSION_TEMPLATE = `# Mission
+
+<!-- One paragraph: what is this team for and why does it exist? -->
+
+## Ownership
+<!-- What does this team own? Cover the relevant dimensions: product surfaces, code areas, processes, integrations, etc. -->
+
+## Goals
+<!-- What is this team focused on right now? List 1–3 active goals. -->
+
+## Common Tasks
+<!-- Recurring tasks this team runs, so agents know what "normal work" looks like -->
+`;
+
+const MEMORY_TEMPLATE = `# Memory
+
+A running log of patterns, preferences, and lessons this team has learned.
+Append new entries at the top. Include a date.
+
+---
+
+<!-- Entry format:
+## YYYY-MM-DD — Title
+What happened and what we learned.
+-->
+`;
+
+const DECISIONS_TEMPLATE = `# Decisions
+
+Key decisions made by this team. Record decisions here so agents and humans
+don't re-litigate them.
+
+| Date | Decision | Rationale | Status |
+|------|----------|-----------|--------|
+| | | | |
+`;
 
 export function registerTeam(program: Command): void {
   const team = program.command('team').description('Manage teams');


### PR DESCRIPTION
## Summary

- `ns team create` now stubs `MISSION.md`, `MEMORY.md`, and `DECISIONS.md` into every new team directory alongside `team.toml`, with templates that guide agents (and humans) filling them in
- Adds **team-creator** agent: designs rosters, delegates to agent-creator first, then scaffolds the team with `ns team create` and fills in the mission artifacts
- Adds **agent-creator** agent: reviews existing agents for patterns/overlap before writing, creates focused prompts organized around owned tasks/workflows, flags subagent candidates for token-heavy or repeated steps
- Bootstraps the `ns-team-builder` team's own artifacts (MISSION, MEMORY, DECISIONS)

## Test plan

- [x] 6 new tests for `createTeam` covering MISSION.md, MEMORY.md, and DECISIONS.md creation and content
- [x] All 260 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)