### PR TITLE
Fix unresponsive UI: node:crypto client leak and stale closure in navigateBack

### DIFF
--- a/src/routes/teams/$teamId/-use-team-page.ts
+++ b/src/routes/teams/$teamId/-use-team-page.ts
@@ -382,15 +382,19 @@ export function useTeamPage(initialData: TeamPageLoaderData) {
   // navigateBack: '-' key logic extracted so it can be called from the
   // global keydown handler that lives in $teamId.tsx
   function navigateBack() {
-    if (view.type === 'chat') {
+    const currentView = viewRef.current;
+    if (currentView.type === 'chat') {
       navigate({ to: '/' });
-    } else if (view.type === 'agent-session' && view.projectId) {
+    } else if (currentView.type === 'agent-session' && currentView.projectId) {
       setView({
         type: 'project-chat',
-        projectId: view.projectId,
-        projectName: view.projectName ?? '',
+        projectId: currentView.projectId,
+        projectName: currentView.projectName ?? '',
       });
-    } else if (view.type === 'project-chat' || view.type === 'agent-session') {
+    } else if (
+      currentView.type === 'project-chat' ||
+      currentView.type === 'agent-session'
+    ) {
       setView({ type: 'chat' });
     }
     setFocusedIdx(-1);

--- a/src/server/team-data.ts
+++ b/src/server/team-data.ts
@@ -1,11 +1,5 @@
 import { createServerFn } from '@tanstack/react-start';
 import type { Message } from '~/db/messages';
-import {
-  getProjectMessages as getProjectMessagesDb,
-  getTeamMessages,
-  insertMessage,
-} from '~/db/messages';
-import { getSession, setSessionSdkId, upsertSession } from '~/db/sessions';
 import { getDb } from './db';
 import type { TeamMeta } from './teams';
 import { orderedMembers, readTeams, resolveCwd } from './teams';
@@ -160,6 +154,14 @@ export async function runConversationLoop({
   runAgentFn?: RunAgentFn;
 }): Promise<void> {
   const { join } = await import('node:path');
+  const {
+    getProjectMessages: getProjectMessagesDb,
+    getTeamMessages,
+    insertMessage,
+  } = await import('~/db/messages');
+  const { getSession, setSessionSdkId, upsertSession } = await import(
+    '~/db/sessions'
+  );
 
   /** Fetch the most recent messages in the right scope (team or project). */
   const getRecentMessages = () =>


### PR DESCRIPTION
## Summary

- **`node:crypto` in client bundle** — PR #18 replaced dynamic imports with static top-level imports for `~/db/messages` and `~/db/sessions` in `team-data.ts`. Those modules use `randomUUID` from `node:crypto`, which Vite externalises in the browser. This caused the JS bundle to throw on load, making the entire UI unresponsive (no keyboard shortcuts, no link clicks). Fixed by moving those imports back to `await import(...)` inside `runConversationLoop`, matching how the `createServerFn` handlers already handled their db imports.
- **Stale closure in `navigateBack`** — The global keydown `useEffect` intentionally omits most state from its deps array and reads everything through refs. `navigateBack` was the exception — it read from `view` state directly, so the handler always saw the initial view. Pressing `-` in project-chat would call `navigate({ to: '/' })` instead of returning to team chat. Fixed by switching `navigateBack` to read `viewRef.current`, consistent with how all other handlers in that effect work.

## Test plan

- [ ] Keyboard shortcuts (`i`, `j`, `k`, `f`, `p`, `a`, `t`) all work from team chat
- [ ] `-` from project chat returns to team chat
- [ ] `-` from agent session with a project returns to project chat
- [ ] `-` from team chat navigates to `/`
- [ ] `bun test`, `bun typecheck`, `bun lint` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)