### PR TITLE
Fix conversation judge: @mentions only route mentioned agents

### DIFF
--- a/src/cli/commands/serve.test.ts
+++ b/src/cli/commands/serve.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadProjectEnv } from './serve';
+
+describe('loadProjectEnv', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'ns-serve-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns an empty object when neither env file exists', () => {
+    expect(loadProjectEnv(dir)).toEqual({});
+  });
+
+  it('parses a .env file', () => {
+    writeFileSync(join(dir, '.env'), 'FOO=bar\nBAZ=qux\n');
+    expect(loadProjectEnv(dir)).toEqual({ FOO: 'bar', BAZ: 'qux' });
+  });
+
+  it('parses a .nightshift/.env file', () => {
+    mkdirSync(join(dir, '.nightshift'));
+    writeFileSync(join(dir, '.nightshift', '.env'), 'HELLO=world\n');
+    expect(loadProjectEnv(dir)).toEqual({ HELLO: 'world' });
+  });
+
+  it('.nightshift/.env values override .env values for the same key', () => {
+    writeFileSync(join(dir, '.env'), 'KEY=from-dotenv\nOTHER=keep\n');
+    mkdirSync(join(dir, '.nightshift'));
+    writeFileSync(join(dir, '.nightshift', '.env'), 'KEY=from-nightshift\n');
+    expect(loadProjectEnv(dir)).toEqual({
+      KEY: 'from-nightshift',
+      OTHER: 'keep',
+    });
+  });
+
+  it('skips comment lines and blank lines', () => {
+    writeFileSync(join(dir, '.env'), '# comment\n\nKEY=val\n');
+    expect(loadProjectEnv(dir)).toEqual({ KEY: 'val' });
+  });
+
+  it('strips inline comments after a value', () => {
+    writeFileSync(join(dir, '.env'), 'KEY=value # comment\n');
+    expect(loadProjectEnv(dir)).toEqual({ KEY: 'value' });
+  });
+
+  it('strips surrounding quotes from values', () => {
+    writeFileSync(
+      join(dir, '.env'),
+      'A="double quoted"\nB=\'single quoted\'\n',
+    );
+    expect(loadProjectEnv(dir)).toEqual({
+      A: 'double quoted',
+      B: 'single quoted',
+    });
+  });
+
+  it('handles values with = signs inside them', () => {
+    writeFileSync(join(dir, '.env'), 'URL=https://example.com?a=1&b=2\n');
+    expect(loadProjectEnv(dir)).toEqual({ URL: 'https://example.com?a=1&b=2' });
+  });
+});

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -1,6 +1,57 @@
 import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Command } from 'commander';
+
+/**
+ * Parse a .env file into a key→value map.
+ * Skips blank lines and `#` comments. Strips surrounding quotes and inline comments.
+ * Later values for the same key win.
+ */
+function parseDotenv(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const raw of content.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const eqIdx = line.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = line.slice(0, eqIdx).trim();
+    let val = line.slice(eqIdx + 1).trim();
+    // Strip surrounding quotes
+    if (
+      (val.startsWith('"') && val.endsWith('"')) ||
+      (val.startsWith("'") && val.endsWith("'"))
+    ) {
+      val = val.slice(1, -1);
+    } else {
+      // Strip inline comment (unquoted values only)
+      const commentIdx = val.indexOf(' #');
+      if (commentIdx !== -1) val = val.slice(0, commentIdx).trimEnd();
+    }
+    if (key) result[key] = val;
+  }
+  return result;
+}
+
+/**
+ * Load env vars from the project directory.
+ * Priority (highest last, so it wins in spread): process.env → .env → .nightshift/.env
+ * Returns only the file-sourced vars; callers merge with process.env themselves.
+ */
+export function loadProjectEnv(projectDir: string): Record<string, string> {
+  const read = (path: string): Record<string, string> => {
+    try {
+      return parseDotenv(readFileSync(path, 'utf-8'));
+    } catch {
+      return {};
+    }
+  };
+
+  return {
+    ...read(join(projectDir, '.env')),
+    ...read(join(projectDir, '.nightshift', '.env')),
+  };
+}
 
 export function registerServe(program: Command): void {
   program
@@ -8,26 +59,35 @@ export function registerServe(program: Command): void {
     .description('Start the nightshift management UI')
     .option('--port <number>', 'Port to listen on', '3000')
     .action((opts: { port: string }) => {
-      if (!process.env.ANTHROPIC_API_KEY) {
-        console.warn(
-          '[nightshift] Warning: ANTHROPIC_API_KEY is not set.\n' +
-            '  The conversation judge uses the Anthropic API directly and will fall back\n' +
-            '  to the team lead on every turn until the key is configured.\n' +
-            '  Fix: add  export ANTHROPIC_API_KEY=sk-ant-...  to your shell profile (~/.zshrc / ~/.bashrc).',
-        );
-      }
-
       // Resolve the package root from this file's location: src/cli/commands/ -> ../../..
       const packageRoot = join(import.meta.dir, '..', '..', '..');
 
       const projectDir = process.cwd();
+      const fileEnv = loadProjectEnv(projectDir);
+
+      if (!process.env.ANTHROPIC_API_KEY && !fileEnv.ANTHROPIC_API_KEY) {
+        console.warn(
+          '[nightshift] Warning: ANTHROPIC_API_KEY is not set.\n' +
+            '  The conversation judge uses the Anthropic API directly and will fall back\n' +
+            '  to the team lead on every turn until the key is configured.\n' +
+            '  Set it in .nightshift/.env, .env, or your shell profile (~/.zshrc / ~/.bashrc).',
+        );
+      }
+
+      // Merge order: process.env (lowest) → .env → .nightshift/.env (highest)
+      const env = {
+        ...process.env,
+        ...fileEnv,
+        NIGHTSHIFT_PROJECT_DIR: projectDir,
+      };
+
       const child = spawn(
         'bun',
         ['--bun', 'run', 'vite', 'dev', '--port', opts.port],
         {
           cwd: packageRoot,
           stdio: 'inherit',
-          env: { ...process.env, NIGHTSHIFT_PROJECT_DIR: projectDir },
+          env,
         },
       );
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -8,6 +8,15 @@ export function registerServe(program: Command): void {
     .description('Start the nightshift management UI')
     .option('--port <number>', 'Port to listen on', '3000')
     .action((opts: { port: string }) => {
+      if (!process.env.ANTHROPIC_API_KEY) {
+        console.warn(
+          '[nightshift] Warning: ANTHROPIC_API_KEY is not set.\n' +
+            '  The conversation judge uses the Anthropic API directly and will fall back\n' +
+            '  to the team lead on every turn until the key is configured.\n' +
+            '  Fix: add  export ANTHROPIC_API_KEY=sk-ant-...  to your shell profile (~/.zshrc / ~/.bashrc).',
+        );
+      }
+
       // Resolve the package root from this file's location: src/cli/commands/ -> ../../..
       const packageRoot = join(import.meta.dir, '..', '..', '..');
 

--- a/src/server/team-data.test.ts
+++ b/src/server/team-data.test.ts
@@ -267,6 +267,25 @@ describe('runConversationLoop', () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
+  it('stops loop after user @mention agents respond, even when agent does not reply @user', async () => {
+    // Alice responds without @user or any further @mention — loop must still stop
+    const runAgentFn = mock(async () => 'on it');
+    insertMessage(db, 'test-team', 'user', 'hey @alice please help');
+
+    await runConversationLoop({
+      db,
+      teamId: 'test-team',
+      team,
+      cwd: '/tmp',
+      teamMemberMeta,
+      runAgentFn,
+    });
+
+    expect(runAgentFn).toHaveBeenCalledTimes(1);
+    // Judge must NOT be called — explicit user @mention trumps judge routing
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
   it('exits when judge returns no responders', async () => {
     const runAgentFn = mock(async () => '');
     insertMessage(db, 'test-team', 'user', 'any thoughts?');

--- a/src/server/team-data.ts
+++ b/src/server/team-data.ts
@@ -218,6 +218,11 @@ export async function runConversationLoop({
     // Determine who should respond to the last message
     const mentions = parseMentions(lastMessage.content, allAgentNames);
 
+    // Track whether this turn was driven by an explicit @mention in a user message.
+    // After those agents respond we stop — the judge should not add unsolicited agents.
+    const userMentionTrigger =
+      mentions.length > 0 && lastMessage.sender === 'user';
+
     let nextResponders: string[];
     if (mentions.length > 0) {
       // @mentions are authoritative — run exactly those agents, skip the judge
@@ -309,6 +314,10 @@ export async function runConversationLoop({
       // Stop immediately if the agent is handing back to the user
       if (mentionsUser(responseText)) return;
     }
+
+    // When this turn was driven by an explicit @mention in a user message, stop here.
+    // The mentioned agents have responded; don't let the judge queue additional agents.
+    if (userMentionTrigger) break;
   }
 }
 

--- a/src/server/team-data.ts
+++ b/src/server/team-data.ts
@@ -97,12 +97,20 @@ export async function runConversationJudge(
     .replace(/\s*```$/, '')
     .trim();
 
-  const parsed = JSON.parse(text); // throws on invalid JSON — caller handles it
-  if (!Array.isArray(parsed.next_responders)) {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch (err) {
+    throw new Error(
+      `Judge returned invalid JSON: ${err}\nRaw response: ${raw}`,
+    );
+  }
+  const result = parsed as Record<string, unknown>;
+  if (!Array.isArray(result.next_responders)) {
     throw new Error(`Judge returned unexpected shape: ${text}`);
   }
   // Only allow valid agent names
-  return (parsed.next_responders as string[]).filter((r) =>
+  return (result.next_responders as string[]).filter((r) =>
     allAgentNames.includes(r),
   );
 }


### PR DESCRIPTION
## Summary

- **Mention routing bug**: After a user sent `@agent-name`, the mentioned agent responded correctly, but the conversation loop continued and the judge queued additional agents (e.g. the team lead). Fixed by breaking the loop after user-message-triggered @mention agents finish — judge routing only kicks in when no explicit mention was made.
- **API key warning**: `ns serve` now warns at startup when `ANTHROPIC_API_KEY` is not set, so the judge failure is no longer silent. The fix to the underlying auth issue is to add `export ANTHROPIC_API_KEY=sk-ant-...` to your shell profile — no per-repo Claude Code setup is needed.

Closes #22

## Test plan

- [ ] New unit test `stops loop after user @mention agents respond, even when agent does not reply @user` covers the routing fix
- [ ] All 282 existing tests pass (`bun test`)
- [ ] `bun lint` and `bun typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)