### PR TITLE
Test artefact viewer components and remove coverage exemptions

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -10,9 +10,6 @@ coverageIgnore = [
   "src/routes/__root.tsx",
   "src/routes/index.tsx",
   "src/server/db.ts",
-  "src/routes/teams/$teamId/-diff-view.tsx",
-  "src/routes/teams/$teamId/-file-content-view.tsx",
-  "src/routes/teams/$teamId/-files-view.tsx",
 ]
 # coveragePathIgnorePatterns is what Bun 1.3.11 actually respects (substring match on path)
 coveragePathIgnorePatterns = [
@@ -25,7 +22,4 @@ coveragePathIgnorePatterns = [
   "src/routes/__root.tsx",
   "src/routes/index.tsx",
   "src/server/db.ts",
-  "src/routes/teams/$teamId/-diff-view.tsx",
-  "src/routes/teams/$teamId/-file-content-view.tsx",
-  "src/routes/teams/$teamId/-files-view.tsx",
 ]

--- a/src/routes/teams/$teamId/-diff-view.test.tsx
+++ b/src/routes/teams/$teamId/-diff-view.test.tsx
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
+import { DiffView } from './-diff-view';
+
+afterEach(cleanup);
+
+const noStats = { filesChanged: 0, insertions: 0, deletions: 0 };
+
+describe('DiffView', () => {
+  it('shows "No changes on this branch" when diffText is empty', () => {
+    render(<DiffView diffText="" stats={noStats} />);
+    screen.getByText(/No changes on this branch/);
+  });
+
+  it('does not show "No changes" when diffText is non-empty', () => {
+    render(<DiffView diffText="+added line" stats={noStats} />);
+    expect(screen.queryByText(/No changes on this branch/)).toBeNull();
+  });
+
+  it('renders filesChanged count in stats header', () => {
+    render(
+      <DiffView
+        diffText="x"
+        stats={{ filesChanged: 3, insertions: 0, deletions: 0 }}
+      />,
+    );
+    screen.getByText(/3 files changed/);
+  });
+
+  it('renders insertions count in a green span', () => {
+    render(
+      <DiffView
+        diffText="x"
+        stats={{ filesChanged: 1, insertions: 10, deletions: 0 }}
+      />,
+    );
+    const span = screen.getByText('+10');
+    expect(span.className).toContain('text-green');
+  });
+
+  it('renders deletions count in a red span', () => {
+    render(
+      <DiffView
+        diffText="x"
+        stats={{ filesChanged: 1, insertions: 0, deletions: 5 }}
+      />,
+    );
+    const span = screen.getByText('-5');
+    expect(span.className).toContain('text-red');
+  });
+
+  it('applies muted class (not green) to +++ header lines', () => {
+    render(<DiffView diffText="+++ b/file.ts" stats={noStats} />);
+    const span = screen.getByText('+++ b/file.ts');
+    expect(span.className).toContain('text-muted-foreground');
+    expect(span.className).not.toContain('text-green');
+  });
+
+  it('applies muted class (not red) to --- header lines', () => {
+    render(<DiffView diffText="--- a/file.ts" stats={noStats} />);
+    const span = screen.getByText('--- a/file.ts');
+    expect(span.className).toContain('text-muted-foreground');
+    expect(span.className).not.toContain('text-red');
+  });
+
+  it('applies green class to + addition lines', () => {
+    render(<DiffView diffText="+added line" stats={noStats} />);
+    const span = screen.getByText('+added line');
+    expect(span.className).toContain('text-green');
+  });
+
+  it('applies red class to - deletion lines', () => {
+    render(<DiffView diffText="-removed line" stats={noStats} />);
+    const span = screen.getByText('-removed line');
+    expect(span.className).toContain('text-red');
+  });
+
+  it('applies blue class to @@ hunk header lines', () => {
+    render(<DiffView diffText="@@ -1,3 +1,4 @@" stats={noStats} />);
+    const span = screen.getByText('@@ -1,3 +1,4 @@');
+    expect(span.className).toContain('text-blue');
+  });
+
+  it('applies primary font-bold class to diff --git header lines', () => {
+    render(<DiffView diffText="diff --git a/x.ts b/x.ts" stats={noStats} />);
+    const span = screen.getByText('diff --git a/x.ts b/x.ts');
+    expect(span.className).toContain('text-primary');
+    expect(span.className).toContain('font-bold');
+  });
+
+  it('applies foreground class to context lines', () => {
+    // Context lines in unified diffs start with a space; use regex to avoid
+    // getByText's default whitespace normalization stripping the leading space.
+    render(<DiffView diffText=" context line" stats={noStats} />);
+    const span = screen.getByText(/context line/);
+    expect(span.className).toContain('text-foreground');
+  });
+});

--- a/src/routes/teams/$teamId/-file-content-view.test.tsx
+++ b/src/routes/teams/$teamId/-file-content-view.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
+import { FileContentView } from './-file-content-view';
+
+afterEach(cleanup);
+
+describe('FileContentView', () => {
+  it('displays the file path with segments joined by /', () => {
+    render(
+      <FileContentView
+        relPath={['src', 'lib', 'utils.ts']}
+        content="export {}"
+      />,
+    );
+    screen.getByText(/src\/lib\/utils\.ts/);
+  });
+
+  it('renders non-markdown files as raw text in a pre element', () => {
+    const { container } = render(
+      <FileContentView relPath={['script.sh']} content="echo hello" />,
+    );
+    const pre = container.querySelector('pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toContain('echo hello');
+  });
+
+  it('does not use a pre element for .md files', () => {
+    const { container } = render(
+      <FileContentView relPath={['readme.md']} content="# Hello" />,
+    );
+    expect(container.querySelector('pre')).toBeNull();
+  });
+
+  it('renders .md files via Markdown — headings become bold paragraphs', () => {
+    // The custom FlatHeading renders h1–h6 as <p className="font-bold">
+    render(<FileContentView relPath={['readme.md']} content="# Hello world" />);
+    const heading = screen.getByText('Hello world');
+    expect(heading.tagName).toBe('P');
+    expect(heading.className).toContain('font-bold');
+  });
+
+  it('renders .mdx files via Markdown', () => {
+    render(<FileContentView relPath={['doc.mdx']} content="# Title" />);
+    const heading = screen.getByText('Title');
+    expect(heading.tagName).toBe('P');
+    expect(heading.className).toContain('font-bold');
+  });
+
+  it('treats non-markdown extensions as plain text even with markdown syntax', () => {
+    const { container } = render(
+      <FileContentView relPath={['notes.txt']} content="# Not a heading" />,
+    );
+    const pre = container.querySelector('pre');
+    expect(pre?.textContent).toContain('# Not a heading');
+  });
+
+  it('uses the last path segment for extension detection', () => {
+    // Path ends in .ts (not markdown), so renders as pre
+    const { container } = render(
+      <FileContentView relPath={['docs', 'readme.ts']} content="# code" />,
+    );
+    expect(container.querySelector('pre')).not.toBeNull();
+  });
+});

--- a/src/routes/teams/$teamId/-files-view.test.tsx
+++ b/src/routes/teams/$teamId/-files-view.test.tsx
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { FileEntry } from '~/server/artefacts';
+import { FilesView } from './-files-view';
+
+afterEach(cleanup);
+
+function makeEntry(name: string, type: 'file' | 'dir' = 'file'): FileEntry {
+  return { name, type };
+}
+
+function renderView(
+  overrides: Partial<{
+    teamId: string;
+    path: string[];
+    entries: FileEntry[];
+    cursor: number;
+    onSelectEntry: (entry: FileEntry, newPath: string[]) => void;
+    onNavigateCursor: (cursor: number) => void;
+  }> = {},
+) {
+  return render(
+    <FilesView
+      teamId={overrides.teamId ?? 'my-team'}
+      path={overrides.path ?? []}
+      entries={overrides.entries ?? []}
+      cursor={overrides.cursor ?? 0}
+      onSelectEntry={overrides.onSelectEntry ?? (() => {})}
+      onNavigateCursor={overrides.onNavigateCursor ?? (() => {})}
+    />,
+  );
+}
+
+describe('FilesView', () => {
+  it('shows ../ when path is non-empty', () => {
+    renderView({ path: ['subdir'] });
+    screen.getByText('../');
+  });
+
+  it('does not show ../ at the root path', () => {
+    renderView({ path: [] });
+    expect(screen.queryByText('../')).toBeNull();
+  });
+
+  it('shows (empty) when entries list is empty', () => {
+    renderView({ entries: [] });
+    screen.getByText('(empty)');
+  });
+
+  it('does not show (empty) when entries are present', () => {
+    renderView({ entries: [makeEntry('file.md')] });
+    expect(screen.queryByText('(empty)')).toBeNull();
+  });
+
+  it('renders entry names', () => {
+    renderView({ entries: [makeEntry('notes.md')] });
+    screen.getByText('notes.md');
+  });
+
+  it('appends / to directory entries', () => {
+    renderView({ entries: [makeEntry('docs', 'dir')] });
+    screen.getByText('docs/');
+  });
+
+  it('does not append / to file entries', () => {
+    renderView({ entries: [makeEntry('readme.md')] });
+    screen.getByText('readme.md');
+    expect(screen.queryByText('readme.md/')).toBeNull();
+  });
+
+  it('applies text-primary to directory entry name spans', () => {
+    renderView({ entries: [makeEntry('docs', 'dir')] });
+    const span = screen.getByText('docs/');
+    expect(span.className).toContain('text-primary');
+  });
+
+  it('applies text-foreground to file entry name spans', () => {
+    renderView({ entries: [makeEntry('readme.md')] });
+    const span = screen.getByText('readme.md');
+    expect(span.className).toContain('text-foreground');
+  });
+
+  it('applies cursor highlight to entry at cursor index', () => {
+    renderView({
+      entries: [makeEntry('a.md'), makeEntry('b.md')],
+      cursor: 1,
+    });
+    const buttons = screen.getAllByRole('button');
+    expect(buttons[1].className).toContain('bg-primary/10');
+    expect(buttons[0].className).not.toContain('bg-primary/10');
+  });
+
+  it('calls onSelectEntry with the entry and new path when clicked', async () => {
+    const user = userEvent.setup();
+    const onSelectEntry = mock(() => {});
+    const entry = makeEntry('notes.md');
+    renderView({
+      path: ['docs'],
+      entries: [entry],
+      onSelectEntry,
+    });
+    await user.click(screen.getByRole('button'));
+    expect(onSelectEntry).toHaveBeenCalledWith(entry, ['docs', 'notes.md']);
+  });
+
+  it('calls onNavigateCursor with the entry index on mouse enter', async () => {
+    const user = userEvent.setup();
+    const onNavigateCursor = mock(() => {});
+    renderView({
+      entries: [makeEntry('a.md'), makeEntry('b.md')],
+      onNavigateCursor,
+    });
+    const buttons = screen.getAllByRole('button');
+    await user.hover(buttons[1]);
+    expect(onNavigateCursor).toHaveBeenCalledWith(1);
+  });
+
+  it('includes teamId and path in the header title', () => {
+    renderView({ teamId: 'alpha', path: ['docs', 'api'] });
+    screen.getByText(/alpha\/docs\/api/);
+  });
+});


### PR DESCRIPTION
## Summary

- Added 32 tests across three new test files for `DiffView`, `FileContentView`, and `FilesView`
- Removed all three from `coverageIgnore` / `coveragePathIgnorePatterns` in `bunfig.toml`
- All three now report 100% line coverage; overall suite stays at 89% (above the 85% threshold)

These components were exempted at the time the artefact viewer was built but each has real branching logic that warrants coverage:
- **`DiffView`**: 6-branch line colorizer — the `+++`/`---` ordering invariant over `+`/`-` is exactly what tests catch
- **`FileContentView`**: markdown vs plain-text rendering branch (`isMarkdown` on `.md`/`.mdx` extension)
- **`FilesView`**: cursor highlighting, dir/file type styling, `../` breadcrumb, empty state, click/hover callbacks

## Test plan

- [x] `bun test` — 313 pass, 0 fail
- [x] `bun test --coverage` — 89.32% overall, all three new files at 100%
- [x] `bun lint` / `bun typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)