### PR TITLE
Remove conversation judge — deterministic routing

### DIFF
--- a/.nightshift/agents/harness-engineer.md
+++ b/.nightshift/agents/harness-engineer.md
@@ -32,7 +32,7 @@ When changing any harness behaviour:
 
 1. **Enumerate failure modes first.** Read the harness code and list hypotheses before running anything: where could agents get stuck, loop, hallucinate success, or lose session state?
 
-2. **Unit tests with mocks.** Test individual functions — `buildSystemPrompt`, `runConversationJudge`, `shouldFlushThinking`, session state transitions — with mocked SDK responses. Co-locate test files with source (e.g. `agent-runner.test.ts`). Run with `bun test`.
+2. **Unit tests with mocks.** Test individual functions — `buildSystemPrompt`, `shouldFlushThinking`, session state transitions, routing logic in `runConversationLoop` — with mocked SDK responses. Co-locate test files with source (e.g. `agent-runner.test.ts`). Run with `bun test`.
 
 3. **E2E tests with real calls.** Some failure modes only surface with real API responses. Write E2E tests that invoke the full `runAgent` or `runConversationLoop` path. Mark them clearly (e.g. a `// @e2e` comment or dedicated file) so they're not included in normal CI runs.
 

--- a/.nightshift/teams/agent-runner/DECISIONS.md
+++ b/.nightshift/teams/agent-runner/DECISIONS.md
@@ -6,10 +6,8 @@ don't re-litigate them.
 | Date | Decision | Rationale | Status |
 |------|----------|-----------|--------|
 | 2026-04-10 | SQLite with WAL mode as the persistence layer | Single-file DB is sufficient for local-first usage; WAL mode allows concurrent reads without blocking writes | Active |
-| 2026-04-10 | LLM judge (Haiku) decides next agent in conversation loop | Avoids hard-coded routing rules; lets conversation flow naturally based on content | Active |
-| 2026-04-10 | Fall back to team lead when judge fails | Prevents stuck conversations; lead can always re-route | Active |
+| 2026-04-11 | Deterministic routing replaces LLM judge | Predictable behaviour, no extra API call per turn, no hallucination risk; lead acts as orchestrator and is the default handler for user and member messages | Active |
 | 2026-04-10 | 5-minute timeout per agent turn | Guards against hung SDK streams without killing short-lived tasks | Active |
-| 2026-04-10 | Max 6 agent turns per conversation cycle | Prevents runaway loops; human can re-engage after limit | Active |
 | 2026-04-10 | Session resumption via `sdk_session_id` stored in DB | Allows agents to continue multi-turn conversations across restarts | Active |
 | 2026-04-10 | `resetStuckSessions` runs at server startup | Cleans up sessions left in `working` state from crashes; safer than trying to resume unknown state | Active |
 | 2026-04-10 | Agent definitions are plain markdown files with YAML frontmatter | Low barrier to create/edit agents; no DSL to learn | Active |

--- a/.nightshift/teams/agent-runner/MISSION.md
+++ b/.nightshift/teams/agent-runner/MISSION.md
@@ -6,8 +6,8 @@ The agent-runner team owns the harness that brings nightshift agents to life —
 
 **Code areas**
 - `src/server/agent-runner.ts` — core agent execution via Claude Agent SDK (`runAgent`, tool allowlist, streaming callbacks, session resumption)
-- `src/server/team-data.ts` — multi-agent conversation orchestration (`runConversationLoop`, `runConversationJudge`, @mention routing, turn limits, timeouts)
-- `src/server/conversation-timing.spec.md` — judge behaviour specification
+- `src/server/team-data.ts` — multi-agent conversation orchestration (`runConversationLoop`, deterministic @mention routing, turn limits, timeouts)
+- `src/server/conversation-timing.spec.md` — conversation routing rules specification
 - `src/db/sessions.ts` — agent session state machine (idle/working, `sdk_session_id`, stuck-session reset)
 - `src/db/messages.ts` — message persistence (`insertMessage`, `getTeamMessages`, `getProjectMessages`)
 - `src/db/schema.ts` + `src/db/index.ts` — SQLite schema and WAL-mode connection
@@ -29,7 +29,7 @@ The agent-runner team owns the harness that brings nightshift agents to life —
 
 - **Debug a stuck or hung agent** — inspect `sessions` table, check `resetStuckSessions`, trace the 5-minute timeout in `runConversationLoop`
 - **Add a new tool to the runner allowlist** — edit tool list in `agent-runner.ts`, write a test, update docs
-- **Tune conversation routing** — modify `runConversationJudge` prompt or fall-through logic in `team-data.ts`; update `conversation-timing.spec.md` to match
+- **Tune conversation routing** — modify the routing logic in `runConversationLoop` (`team-data.ts`); update `conversation-timing.spec.md` to match
 - **Update a core harness system prompt** — edit the relevant `.spec.md` first, then update inflation code in `buildSystemPrompt`
 - **Add or alter a DB column** — update `schema.ts`, write a migration, update affected query helpers
 - **Add a CLI subcommand** — scaffold in `src/cli/commands/`, wire into `src/cli/index.ts`, co-locate tests

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -65,15 +65,6 @@ export function registerServe(program: Command): void {
       const projectDir = process.cwd();
       const fileEnv = loadProjectEnv(projectDir);
 
-      if (!process.env.ANTHROPIC_API_KEY && !fileEnv.ANTHROPIC_API_KEY) {
-        console.warn(
-          '[nightshift] Warning: ANTHROPIC_API_KEY is not set.\n' +
-            '  The conversation judge uses the Anthropic API directly and will fall back\n' +
-            '  to the team lead on every turn until the key is configured.\n' +
-            '  Set it in .nightshift/.env, .env, or your shell profile (~/.zshrc / ~/.bashrc).',
-        );
-      }
-
       // Merge order: process.env (lowest) → .env → .nightshift/.env (highest)
       const env = {
         ...process.env,

--- a/src/server/conversation-timing.spec.md
+++ b/src/server/conversation-timing.spec.md
@@ -1,83 +1,71 @@
-# Conversation Timing
+# Conversation Routing
 
-You are the conversation routing judge for a nightshift AI agent team. Your job is to decide which agents, if any, should respond next after the latest message in a team chat conversation.
+This file specifies the deterministic routing rules used by `runConversationLoop` (team-data.ts) to decide which agent responds next after each message. There is no LLM judge — routing is based entirely on the last message's sender and @mention content.
 
-## Input
+## Routing Rules
 
-You will receive:
-- A **Team Roster** listing each agent by name, with the lead marked
-- The **Conversation** showing recent messages in chronological order, with the most recent at the bottom
+### @user mention (any sender)
+Stop the loop and wait for the human. The conversation has been explicitly handed back.
 
-## Output
+### User message — no @mentions
+The **team lead** responds. The lead is the user's primary point of contact.
 
-Respond with a single JSON object and **nothing else** — no explanation, no markdown, just the JSON:
+### User message — with @agent mentions
+The **mentioned agents** respond. This is an explicit routing instruction from the human.
 
-```json
-{ "next_responders": ["agent-name"] }
-```
+### Team lead message — no @mentions
+**Stop the loop.** A lead message without mentions is assumed to be directed at the user.
 
-Return an empty array when the conversation should pause and wait for the user:
+### Team lead message — with @agent mentions
+The **mentioned agents** respond. The lead is delegating work.
 
-```json
-{ "next_responders": [] }
-```
+### Non-lead agent message — no @mentions
+The **team lead** responds. The lead coordinates all agent work and fields member output.
 
-## Decision Rules
+### Non-lead agent message — with @agent mentions
+The **mentioned agents** respond. This is an explicit handoff between members.
 
-### Pause and wait for the user (`[]`) when:
-- The latest agent message asks the user a direct question
-- The latest agent message is a completed status update or summary with no open items
-- The conversation has reached a natural stopping point (all tasks assigned, plan confirmed, etc.)
-- An agent message contains `@user`
+## Constraints
 
-### Default to the lead
-- The lead is the users primary point of contact
-- Their job is to translate the users needs into work for the team, oversee that work, and report back to the user
-- If it's not obvious who should respond, default to the lead
-- Only route to other team members when a clear request for their input or work has been made
-
-### Route to another agent when:
-- There is clearly unfinished work that a specific team member should pick up
-- The last message hands off responsibility to another agent (even without an explicit @mention)
-- Important context was just surfaced that another agent needs to act on before work can continue
-
-### Constraints:
-- Never route to the agent who sent the most recent message (avoid immediate loops)
-- Keep responder lists *tight*. Only the people who obviously need to respond should respond
-- Avoid adding every team member as a responder
-- When in doubt, return `[]` and wait for the user
+- A 5-minute timeout per agent turn guards against hung SDK streams.
 
 ## Examples
 
-**Example 1** — explicit handoff, route to tech-lead:
+**Example 1** — user asks a question, lead handles it:
 ```
-Team: project-lead (lead), product-manager, tech-lead
-Conversation:
-product-manager: Requirements are clear. We need email/password login. @tech-lead please implement.
+User: What's the status of the login feature?
+→ team lead responds
+Lead: Everything is on track. @user I'll have an update by end of day.
+→ @user detected → stop
 ```
-→ `{ "next_responders": ["tech-lead"] }`
 
-**Example 2** — agent asked user a question, wait:
+**Example 2** — user delegates directly to a member:
 ```
-Team: project-lead (lead), product-manager, tech-lead
-Conversation:
-project-lead: Should we use OAuth or simple email/password for this login page?
+User: @bob please review the PR.
+→ bob responds
+Bob: Done, LGTM. No issues.
+→ bob (non-lead, no mentions) → lead responds
+Lead: @user Bob has reviewed the PR and it looks good.
+→ @user detected → stop
 ```
-→ `{ "next_responders": [] }`
 
-**Example 3** — work completed, wait:
+**Example 3** — lead coordinates team:
 ```
-Team: project-lead (lead), tech-lead
-Conversation:
-tech-lead: Done. The login page is implemented and all tests pass.
+User: Implement the checkout flow.
+→ lead responds
+Lead: @alice please implement the backend. @bob handle the frontend.
+→ alice and bob respond (in sequence)
+Alice: Backend done.
+Bob: Frontend done.
+→ alice and bob (non-lead, no mentions) → lead responds each time
+Lead: @user The checkout flow is fully implemented and ready for review.
+→ @user detected → stop
 ```
-→ `{ "next_responders": [] }`
 
-**Example 4** — implicit handoff, route to product-manager:
+**Example 4** — lead signals completion to user:
 ```
-Team: project-lead (lead), product-manager, tech-lead
-Conversation:
-User: We need to redesign the checkout flow.
-project-lead: Good idea. Product-manager, can you define the requirements?
+User: Summarise what was shipped today.
+→ lead responds
+Lead: Today we shipped the login page, the checkout flow, and fixed three bugs.
+→ lead, no mentions → stop (assumed for user)
 ```
-→ `{ "next_responders": ["product-manager"] }`

--- a/src/server/team-data.test.ts
+++ b/src/server/team-data.test.ts
@@ -1,28 +1,8 @@
-import { mock } from 'bun:test';
-
 // ---------------------------------------------------------------------------
-// Module mocks — must be declared before any imports that trigger the mocked
-// modules. Bun hoists mock.module() calls above all other imports.
+// Regular imports
 // ---------------------------------------------------------------------------
 
-// Mock @anthropic-ai/sdk so runConversationJudge tests don't hit the real API.
-// We do NOT mock ./agent-runner at module level — instead runConversationLoop
-// accepts an injectable runAgentFn so individual tests can pass a mock directly.
-const mockCreate = mock(async (_opts: unknown) => ({
-  content: [{ type: 'text', text: '{"next_responders":[]}' }],
-}));
-
-mock.module('@anthropic-ai/sdk', () => ({
-  default: class MockAnthropic {
-    messages = { create: mockCreate };
-  },
-}));
-
-// ---------------------------------------------------------------------------
-// Regular imports (after mocks are registered)
-// ---------------------------------------------------------------------------
-
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 import { type Database, openDb } from '~/db/index';
 import {
   getProjectMessages,
@@ -30,11 +10,7 @@ import {
   insertMessage,
 } from '~/db/messages';
 import { getSession } from '~/db/sessions';
-import {
-  parseMentions,
-  runConversationJudge,
-  runConversationLoop,
-} from './team-data';
+import { parseMentions, runConversationLoop } from './team-data';
 import type { TeamMeta } from './teams';
 
 // ---------------------------------------------------------------------------
@@ -80,126 +56,6 @@ describe('parseMentions', () => {
 });
 
 // ---------------------------------------------------------------------------
-// runConversationJudge
-// ---------------------------------------------------------------------------
-
-const baseTeam: TeamMeta = {
-  name: 'test-team',
-  lead: 'alice',
-  members: ['alice', 'bob'],
-};
-
-const fakeMsgs = [
-  {
-    id: '1',
-    team_id: 'test-team',
-    project_id: null,
-    sender: 'user',
-    content: 'Hello team',
-    mentions: '[]',
-    created_at: Date.now(),
-  },
-];
-
-describe('runConversationJudge', () => {
-  beforeEach(() => {
-    mockCreate.mockReset();
-  });
-
-  const judgePrompt = 'You are a routing judge.';
-
-  it('returns valid agent names from a clean JSON response', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: 'text', text: '{"next_responders":["alice","bob"]}' }],
-    });
-    const result = await runConversationJudge(
-      fakeMsgs,
-      baseTeam,
-      ['alice', 'bob'],
-      judgePrompt,
-    );
-    expect(result).toEqual(['alice', 'bob']);
-  });
-
-  it('strips markdown code fences before parsing', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [
-        {
-          type: 'text',
-          text: '```json\n{"next_responders":["alice"]}\n```',
-        },
-      ],
-    });
-    const result = await runConversationJudge(
-      fakeMsgs,
-      baseTeam,
-      ['alice'],
-      judgePrompt,
-    );
-    expect(result).toEqual(['alice']);
-  });
-
-  it('throws on invalid JSON', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: 'text', text: 'not json at all' }],
-    });
-    await expect(
-      runConversationJudge(fakeMsgs, baseTeam, ['alice'], judgePrompt),
-    ).rejects.toThrow();
-  });
-
-  it('throws when next_responders key is missing', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: 'text', text: '{"responders":["alice"]}' }],
-    });
-    await expect(
-      runConversationJudge(fakeMsgs, baseTeam, ['alice'], judgePrompt),
-    ).rejects.toThrow('unexpected shape');
-  });
-
-  it('filters out unknown agent names', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [
-        {
-          type: 'text',
-          text: '{"next_responders":["alice","phantom-agent"]}',
-        },
-      ],
-    });
-    const result = await runConversationJudge(
-      fakeMsgs,
-      baseTeam,
-      ['alice', 'bob'],
-      judgePrompt,
-    );
-    expect(result).toEqual(['alice']);
-  });
-
-  it('returns [] when next_responders is empty', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: 'text', text: '{"next_responders":[]}' }],
-    });
-    const result = await runConversationJudge(
-      fakeMsgs,
-      baseTeam,
-      ['alice', 'bob'],
-      judgePrompt,
-    );
-    expect(result).toEqual([]);
-  });
-
-  it('passes the system prompt to the API', async () => {
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: 'text', text: '{"next_responders":[]}' }],
-    });
-    await runConversationJudge(fakeMsgs, baseTeam, ['alice'], 'custom prompt');
-    expect(mockCreate).toHaveBeenCalledWith(
-      expect.objectContaining({ system: 'custom prompt' }),
-    );
-  });
-});
-
-// ---------------------------------------------------------------------------
 // runConversationLoop
 // ---------------------------------------------------------------------------
 
@@ -218,11 +74,6 @@ describe('runConversationLoop', () => {
 
   beforeEach(() => {
     db = openDb(':memory:');
-    mockCreate.mockReset();
-    // Default judge: return no responders so the loop exits cleanly
-    mockCreate.mockResolvedValue({
-      content: [{ type: 'text', text: '{"next_responders":[]}' }],
-    });
   });
 
   afterEach(() => {
@@ -245,49 +96,9 @@ describe('runConversationLoop', () => {
     expect(runAgentFn).not.toHaveBeenCalled();
   });
 
-  it('routes to @mentioned agents and skips the judge for that turn', async () => {
-    // Alice replies with @user so the loop exits immediately — no second judge call
-    const runAgentFn = mock(async () => 'done, @user please review');
-    insertMessage(db, 'test-team', 'user', 'hey @alice please help');
-
-    await runConversationLoop({
-      db,
-      teamId: 'test-team',
-      team,
-      cwd: '/tmp',
-      teamMemberMeta,
-      runAgentFn,
-    });
-
-    expect(runAgentFn).toHaveBeenCalledTimes(1);
-    // Alice's response was inserted into the DB — confirming she was the one routed to
-    const msgs = getTeamMessages(db, 'test-team');
-    expect(msgs.some((m) => m.sender === 'alice')).toBe(true);
-    // Judge should not have been called — @mention was explicit and alice handed back to user
-    expect(mockCreate).not.toHaveBeenCalled();
-  });
-
-  it('stops loop after user @mention agents respond, even when agent does not reply @user', async () => {
-    // Alice responds without @user or any further @mention — loop must still stop
-    const runAgentFn = mock(async () => 'on it');
-    insertMessage(db, 'test-team', 'user', 'hey @alice please help');
-
-    await runConversationLoop({
-      db,
-      teamId: 'test-team',
-      team,
-      cwd: '/tmp',
-      teamMemberMeta,
-      runAgentFn,
-    });
-
-    expect(runAgentFn).toHaveBeenCalledTimes(1);
-    // Judge must NOT be called — explicit user @mention trumps judge routing
-    expect(mockCreate).not.toHaveBeenCalled();
-  });
-
-  it('exits when judge returns no responders', async () => {
-    const runAgentFn = mock(async () => '');
+  it('routes to team lead when user sends a message with no @mentions', async () => {
+    // Lead responds with @user to stop cleanly
+    const runAgentFn = mock(async () => '@user here is my answer');
     insertMessage(db, 'test-team', 'user', 'any thoughts?');
 
     await runConversationLoop({
@@ -299,34 +110,15 @@ describe('runConversationLoop', () => {
       runAgentFn,
     });
 
-    expect(runAgentFn).not.toHaveBeenCalled();
-  });
-
-  it('falls back to lead when judge throws, unless lead already spoke', async () => {
-    mockCreate.mockRejectedValue(new Error('API error'));
-    const runAgentFn = mock(async () => '');
-    insertMessage(db, 'test-team', 'user', 'help please');
-
-    await runConversationLoop({
-      db,
-      teamId: 'test-team',
-      team,
-      cwd: '/tmp',
-      teamMemberMeta,
-      runAgentFn,
-    });
-
     expect(runAgentFn).toHaveBeenCalledTimes(1);
-    // Alice (lead) was the fallback responder — her message appears in the DB
     const msgs = getTeamMessages(db, 'test-team');
     expect(msgs.some((m) => m.sender === 'alice')).toBe(true);
   });
 
-  it('does not fall back to lead when lead is the last speaker', async () => {
-    mockCreate.mockRejectedValue(new Error('API error'));
-    const runAgentFn = mock(async () => '');
-    // Alice (lead) is the last sender — fallback should be skipped
-    insertMessage(db, 'test-team', 'alice', 'I already replied');
+  it('routes to @mentioned agents when user includes @mentions', async () => {
+    // Bob responds with @user so the loop exits after one turn
+    const runAgentFn = mock(async () => '@user done');
+    insertMessage(db, 'test-team', 'user', 'hey @bob please help');
 
     await runConversationLoop({
       db,
@@ -337,68 +129,56 @@ describe('runConversationLoop', () => {
       runAgentFn,
     });
 
-    expect(runAgentFn).not.toHaveBeenCalled();
-  });
-
-  it('stops at MAX_AGENT_TURNS even when judge returns more agents', async () => {
-    const manyAgents = ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7'];
-    const bigTeam: TeamMeta = {
-      name: 'big-team',
-      lead: 'a1',
-      members: manyAgents,
-    };
-    const bigTeamMeta = manyAgents.map((name, i) => ({
-      name,
-      description: `Agent ${i + 1}`,
-      isLead: name === 'a1',
-    }));
-    const runAgentFn = mock(async () => '');
-
-    mockCreate.mockResolvedValueOnce({
-      content: [
-        {
-          type: 'text',
-          text: `{"next_responders":${JSON.stringify(manyAgents)}}`,
-        },
-      ],
-    });
-    insertMessage(db, 'big-team', 'user', 'everyone respond');
-
-    await runConversationLoop({
-      db,
-      teamId: 'big-team',
-      team: bigTeam,
-      cwd: '/tmp',
-      teamMemberMeta: bigTeamMeta,
-      runAgentFn,
-    });
-
-    expect(runAgentFn).toHaveBeenCalledTimes(6);
-  });
-
-  it('does not run the same agent twice across loop iterations', async () => {
-    // Judge returns alice on two consecutive calls; alice only runs the first time
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: 'text', text: '{"next_responders":["alice"]}' }],
-    });
-    mockCreate.mockResolvedValueOnce({
-      content: [{ type: 'text', text: '{"next_responders":["alice"]}' }],
-    });
-    // alice returns '' (no @user / no @mentions) so the loop goes back to the judge
-    const runAgentFn = mock(async () => '');
-    insertMessage(db, 'test-team', 'user', 'help please');
-
-    await runConversationLoop({
-      db,
-      teamId: 'test-team',
-      team,
-      cwd: '/tmp',
-      teamMemberMeta,
-      runAgentFn,
-    });
-
-    // alice ran once; second judge call returned alice again but respondedAgents blocked her
     expect(runAgentFn).toHaveBeenCalledTimes(1);
+    const msgs = getTeamMessages(db, 'test-team');
+    expect(msgs.some((m) => m.sender === 'bob')).toBe(true);
+  });
+
+  it('routes non-lead agent response to team lead', async () => {
+    // Bob responds "done" (no mentions) → alice (lead) responds → @user stops loop
+    let callCount = 0;
+    const runAgentFn = mock(async () => {
+      callCount++;
+      return callCount === 1
+        ? 'done' // bob's response — no @mentions, routes to lead
+        : '@user looks good'; // alice's response — @user stops the loop
+    });
+    insertMessage(db, 'test-team', 'user', 'hey @bob please help');
+
+    await runConversationLoop({
+      db,
+      teamId: 'test-team',
+      team,
+      cwd: '/tmp',
+      teamMemberMeta,
+      runAgentFn,
+    });
+
+    // bob ran first, then alice (lead) handled bob's message
+    expect(runAgentFn).toHaveBeenCalledTimes(2);
+    const msgs = getTeamMessages(db, 'test-team');
+    expect(msgs.some((m) => m.sender === 'bob')).toBe(true);
+    expect(msgs.some((m) => m.sender === 'alice')).toBe(true);
+  });
+
+  it('stops when team lead sends a message with no @mentions', async () => {
+    // Alice (lead) responds with no @mentions → assumed to be for user, stop
+    const runAgentFn = mock(async () => 'here is my answer');
+    insertMessage(db, 'test-team', 'user', 'any thoughts?');
+
+    await runConversationLoop({
+      db,
+      teamId: 'test-team',
+      team,
+      cwd: '/tmp',
+      teamMemberMeta,
+      runAgentFn,
+    });
+
+    // Lead ran once and stopped — no second turn
+    expect(runAgentFn).toHaveBeenCalledTimes(1);
+    const msgs = getTeamMessages(db, 'test-team');
+    expect(msgs.some((m) => m.sender === 'alice')).toBe(true);
   });
 
   it('scopes messages to projectId when provided', async () => {

--- a/src/server/team-data.ts
+++ b/src/server/team-data.ts
@@ -13,7 +13,6 @@ export type AgentSessionMessage = {
   parent_tool_use_id: null;
 };
 
-const MAX_AGENT_TURNS = 6;
 const AGENT_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
 
 /** Extract @name mentions from message content, matched against known names. */
@@ -53,68 +52,6 @@ async function readTeamMemberMeta(
   );
 }
 
-/**
- * LLM judge: given recent conversation, decides which agents (if any) should
- * respond next. Returns an empty array to signal "wait for user".
- *
- * The system prompt is passed in — read it once at the call site so this
- * function stays pure and independently testable.
- */
-export async function runConversationJudge(
-  messages: Message[],
-  team: TeamMeta,
-  allAgentNames: string[],
-  systemPrompt: string,
-): Promise<string[]> {
-  const roster = allAgentNames
-    .map((name) => `- ${name}${name === team.lead ? ' (lead)' : ''}`)
-    .join('\n');
-
-  const history = messages
-    .slice(-15)
-    .map((m) => `${m.sender === 'user' ? 'User' : m.sender}: ${m.content}`)
-    .join('\n');
-
-  const userPrompt = `## Team Roster\n${roster}\n\n## Conversation\n${history}`;
-
-  const { default: Anthropic } = await import('@anthropic-ai/sdk');
-  const client = new Anthropic();
-  const response = await client.messages.create({
-    model: 'claude-haiku-4-5-20251001',
-    max_tokens: 200,
-    system: systemPrompt,
-    messages: [{ role: 'user', content: userPrompt }],
-  });
-
-  const raw =
-    response.content[0].type === 'text'
-      ? response.content[0].text.trim()
-      : '{}';
-
-  // Strip markdown code fences if the model wrapped the JSON (e.g. ```json ... ```)
-  const text = raw
-    .replace(/^```(?:json)?\s*/i, '')
-    .replace(/\s*```$/, '')
-    .trim();
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(text);
-  } catch (err) {
-    throw new Error(
-      `Judge returned invalid JSON: ${err}\nRaw response: ${raw}`,
-    );
-  }
-  const result = parsed as Record<string, unknown>;
-  if (!Array.isArray(result.next_responders)) {
-    throw new Error(`Judge returned unexpected shape: ${text}`);
-  }
-  // Only allow valid agent names
-  return (result.next_responders as string[]).filter((r) =>
-    allAgentNames.includes(r),
-  );
-}
-
 type RunAgentFn = (opts: {
   agentName: string;
   userMessage: string;
@@ -133,12 +70,15 @@ type RunAgentFn = (opts: {
  * Runs the multi-agent conversation loop until the conversation reaches a
  * natural pause point or MAX_AGENT_TURNS is hit.
  *
- * Each iteration looks at the last message in the DB:
- *   - If it contains @mentions → those agents respond (judge is skipped)
- *   - If no @mentions → the judge decides who (if anyone) responds next
+ * Routing is fully deterministic — no LLM judge. Each iteration inspects
+ * the last message:
+ *   - @user mention → stop; hand back to human
+ *   - User message, no @mentions → team lead responds
+ *   - Any message with @agent mentions → those agents respond
+ *   - Team lead message, no @mentions → stop; assumed to be for user
+ *   - Non-lead agent message, no @mentions → team lead responds
  *
- * The loop stops when @user is mentioned, the judge returns [], or we hit
- * the turn limit.
+ * The 5-minute per-agent timeout is the only guard against runaway turns.
  */
 export async function runConversationLoop({
   db,
@@ -203,77 +143,40 @@ export async function runConversationLoop({
 
   const runAgentImpl = runAgentFn ?? defaultRunAgent;
 
-  // Read the judge system prompt once before entering the loop — avoid a
-  // disk read on every iteration and keep runConversationJudge pure.
-  const { readFile } = await import('node:fs/promises');
-  const specPath = new URL('./conversation-timing.spec.md', import.meta.url)
-    .pathname;
-  const judgeSystemPrompt = await readFile(specPath, 'utf-8');
-
   const allAgentNames = teamMemberMeta.map((m) => m.name);
-  const respondedAgents = new Set<string>();
   const teamFolder = join('.nightshift', 'teams', team.name);
-  let totalTurns = 0;
 
-  while (totalTurns < MAX_AGENT_TURNS) {
+  while (true) {
     const recentMessages = getRecentMessages();
     const lastMessage = recentMessages[recentMessages.length - 1];
     if (!lastMessage) break;
 
-    // A @user mention means the conversation is explicitly handing back to the user
+    // @user mention → conversation explicitly handed back to human
     if (mentionsUser(lastMessage.content)) break;
 
-    // Determine who should respond to the last message
     const mentions = parseMentions(lastMessage.content, allAgentNames);
 
-    // Track whether this turn was driven by an explicit @mention in a user message.
-    // After those agents respond we stop — the judge should not add unsolicited agents.
-    const userMentionTrigger =
-      mentions.length > 0 && lastMessage.sender === 'user';
-
     let nextResponders: string[];
-    if (mentions.length > 0) {
-      // @mentions are authoritative — run exactly those agents, skip the judge
-      nextResponders = mentions.filter((n) => !respondedAgents.has(n));
-    } else {
-      // No @mentions — ask the judge
-      let judgeResult: string[] = [];
-      try {
-        judgeResult = await runConversationJudge(
-          recentMessages,
-          team,
-          allAgentNames,
-          judgeSystemPrompt,
-        );
-      } catch (err) {
-        // Judge failed (API error, bad JSON, etc.) — fall back to the lead,
-        // unless the lead just spoke (which would create a loop).
-        console.error(
-          '[nightshift] conversation judge failed, falling back to lead:',
-          err,
-        );
-        const lead = team.lead;
-        if (
-          lastMessage.sender !== lead &&
-          !respondedAgents.has(lead) &&
-          allAgentNames.includes(lead)
-        ) {
-          judgeResult = [lead];
-        }
-      }
 
-      nextResponders = judgeResult.filter((n) => !respondedAgents.has(n));
+    if (mentions.length > 0) {
+      // Explicit @mentions are authoritative — always route to the named agents
+      nextResponders = mentions;
+    } else if (lastMessage.sender === 'user') {
+      // User message with no @mentions → team lead handles it
+      nextResponders = allAgentNames.includes(team.lead) ? [team.lead] : [];
+    } else if (lastMessage.sender === team.lead) {
+      // Team lead sent a message without any @mentions →
+      // assumed to be directed at the user; pause and wait
+      break;
+    } else {
+      // Non-lead agent sent a message with no @mentions → team lead fields it
+      nextResponders = allAgentNames.includes(team.lead) ? [team.lead] : [];
     }
 
     if (nextResponders.length === 0) break;
 
     // Run each queued agent in sequence, inserting messages into the DB as they finish
     for (const agentName of nextResponders) {
-      if (totalTurns >= MAX_AGENT_TURNS) break;
-
-      totalTurns++;
-      respondedAgents.add(agentName);
-
       const chatContext = getRecentMessages();
       const triggerContent = chatContext[chatContext.length - 1]?.content ?? '';
 
@@ -306,7 +209,10 @@ export async function runConversationLoop({
         console.error(`[nightshift] agent ${agentName} failed:`, err);
         // Force the session idle in case runAgent's finally block never ran
         upsertSession(db, teamId, agentName, 'idle', undefined, projectId);
-        break;
+        // Return rather than break — the failed agent never inserted a message,
+        // so the last DB message is unchanged. Continuing the outer loop would
+        // re-route to the same agent and loop forever.
+        return;
       }
 
       const mentionedAgents = parseMentions(responseText, allAgentNames);
@@ -322,10 +228,6 @@ export async function runConversationLoop({
       // Stop immediately if the agent is handing back to the user
       if (mentionsUser(responseText)) return;
     }
-
-    // When this turn was driven by an explicit @mention in a user message, stop here.
-    // The mentioned agents have responded; don't let the judge queue additional agents.
-    if (userMentionTrigger) break;
   }
 }
 


### PR DESCRIPTION
## Summary

- Removes `runConversationJudge` (Haiku API call on every turn) and replaces it with deterministic rules in `runConversationLoop`:
  - User (no @mentions) → team lead
  - Any message with @mentions → those agents
  - Team lead (no @mentions) → stop (assumed for user)
  - Non-lead agent (no @mentions) → team lead
  - Any @user mention → stop
- Removes `MAX_AGENT_TURNS` — the system is autonomous by design; agents stop when they're done, not when a counter runs out
- Removes `respondedNonLeadAgents` dedup guard — explicit @mentions are intent, agents can be mentioned as many times as needed
- Removes the `ANTHROPIC_API_KEY` warning in `serve.ts` (no longer needed)
- Updates `conversation-timing.spec.md` to document the new routing rules with examples

## Test plan

- [ ] `bun test` — 313 tests pass
- [ ] `bun lint` — clean
- [ ] `bun typecheck` — clean
- [ ] Verify team lead responds to plain user messages
- [ ] Verify explicit @mentions route correctly
- [ ] Verify team lead message with no @mentions stops the loop

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)