### PR TITLE
Fix project worktrees not created from UI; agents run in wrong cwd

### DIFF
--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -7,9 +7,9 @@ import { getDbPath, openDb } from '~/db/index';
 import {
   branchExists,
   getOpenProjectsByName,
-  insertProject,
   markProjectMerged,
 } from '~/db/projects';
+import { createProjectWithWorktree } from '~/server/worktrees';
 import { assertInitialized, assertNotExists, assertValidName } from '../fs';
 
 function git(args: string[], cwd: string): string {
@@ -38,8 +38,14 @@ export async function createProject(
   const worktreePath = join(cwd, '.nightshift', 'worktrees', name);
   await assertNotExists(worktreePath, `Project already exists: ${name}`);
 
-  git(['worktree', 'add', worktreePath, '-b', branch], cwd);
-  insertProject(resolvedDb, name, team, branch);
+  await createProjectWithWorktree(
+    cwd,
+    worktreePath,
+    name,
+    team,
+    branch,
+    resolvedDb,
+  );
 }
 
 export async function mergeProject(

--- a/src/server/agent-runner.test.ts
+++ b/src/server/agent-runner.test.ts
@@ -505,4 +505,60 @@ You are a test agent.`);
     const result = await runAgent(BASE_AGENT_ARGS);
     expect(result).toBe('');
   });
+
+  it('passes cwd to SDK when no worktreeDir is given', async () => {
+    mockQuery.mockReturnValue(
+      makeStream([{ type: 'result', subtype: 'success', result: 'done' }]),
+    );
+
+    await runAgent({ ...BASE_AGENT_ARGS, cwd: '/repo-root' });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({ cwd: '/repo-root' }),
+      }),
+    );
+  });
+
+  it('passes worktreeDir to SDK as cwd when provided', async () => {
+    mockQuery.mockReturnValue(
+      makeStream([{ type: 'result', subtype: 'success', result: 'done' }]),
+    );
+
+    await runAgent({
+      ...BASE_AGENT_ARGS,
+      cwd: '/repo-root',
+      worktreeDir: '/repo-root/.nightshift/worktrees/my-feature',
+    });
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: expect.objectContaining({
+          cwd: '/repo-root/.nightshift/worktrees/my-feature',
+        }),
+      }),
+    );
+  });
+
+  it('reads agent metadata from cwd (git root) even when worktreeDir differs', async () => {
+    mockQuery.mockReturnValue(
+      makeStream([{ type: 'result', subtype: 'success', result: 'done' }]),
+    );
+
+    await runAgent({
+      ...BASE_AGENT_ARGS,
+      cwd: '/repo-root',
+      worktreeDir: '/repo-root/.nightshift/worktrees/my-feature',
+    });
+
+    // readFile should have been called with the git-root path, not the worktree path
+    expect(mockReadFile).toHaveBeenCalledWith(
+      expect.stringContaining('/repo-root/.nightshift/agents/test-agent.md'),
+      'utf-8',
+    );
+    expect(mockReadFile).not.toHaveBeenCalledWith(
+      expect.stringContaining('worktrees'),
+      'utf-8',
+    );
+  });
 });

--- a/src/server/agent-runner.ts
+++ b/src/server/agent-runner.ts
@@ -112,6 +112,7 @@ export async function runAgent({
   teamFolder,
   projectBranch,
   cwd,
+  worktreeDir,
   existingSdkSessionId,
   onStatus,
   onSessionId,
@@ -123,7 +124,17 @@ export async function runAgent({
   teamName?: string;
   teamFolder?: string;
   projectBranch?: string;
+  /**
+   * Git root — used to locate nightshift config files (.nightshift/agents/,
+   * .nightshift/teams/). Always the repo root, even for project agents.
+   */
   cwd: string;
+  /**
+   * Worktree directory for the project. When set, Claude Code runs here so it
+   * can edit files on the project branch. Nightshift config is still read from
+   * `cwd` (the repo root).
+   */
+  worktreeDir?: string;
   /** Pass an existing SDK session ID to resume a prior conversation. */
   existingSdkSessionId?: string;
   /** Called whenever the agent's status changes (tool use, thinking, idle). */
@@ -134,6 +145,7 @@ export async function runAgent({
   const { query } = await import('@anthropic-ai/claude-agent-sdk');
 
   const { join } = await import('node:path');
+  // Always read agent metadata from the repo root, not the worktree.
   const meta = await readAgentMeta(cwd, agentName);
   const resolvedTeamName = teamName ?? agentName;
   const resolvedTeamFolder =
@@ -155,7 +167,7 @@ export async function runAgent({
     const stream = query({
       prompt: userMessage,
       options: {
-        cwd,
+        cwd: worktreeDir ?? cwd,
         allowedTools: [
           'Read',
           'Write',

--- a/src/server/artefacts.ts
+++ b/src/server/artefacts.ts
@@ -99,40 +99,6 @@ export async function readTeamFile(
   return readFile(filePath, 'utf8');
 }
 
-/** Find the filesystem path of the worktree that has `branch` checked out. */
-function findWorktreeForBranch(
-  cwd: string,
-  branch: string,
-  execFileSync: typeof import('node:child_process')['execFileSync'],
-): string | null {
-  let output: string;
-  try {
-    output = execFileSync('git', ['worktree', 'list', '--porcelain'], {
-      cwd,
-      stdio: 'pipe',
-    }).toString();
-  } catch {
-    return null;
-  }
-  // Porcelain format: blank-line-separated blocks of:
-  //   worktree <path>
-  //   HEAD <sha>
-  //   branch refs/heads/<name>   (or "detached")
-  for (const block of output.split('\n\n')) {
-    const lines = block.split('\n');
-    const pathLine = lines.find((l) => l.startsWith('worktree '));
-    const branchLine = lines.find((l) => l.startsWith('branch '));
-    if (!pathLine || !branchLine) continue;
-    const worktreePath = pathLine.slice('worktree '.length).trim();
-    const worktreeBranch = branchLine
-      .slice('branch '.length)
-      .trim()
-      .replace(/^refs\/heads\//, '');
-    if (worktreeBranch === branch) return worktreePath;
-  }
-  return null;
-}
-
 export async function getProjectDiff(
   cwd: string,
   branch: string,
@@ -157,8 +123,9 @@ export async function getProjectDiff(
   // This is equivalent to `git diff main` — it captures committed changes,
   // staged changes, and unstaged tracked changes all in one unified diff,
   // avoiding duplicate sections when a file has both committed and uncommitted changes.
+  const { findProjectWorktreePath } = await import('./worktrees');
   const worktreePath = baseSha
-    ? findWorktreeForBranch(cwd, branch, execFileSync)
+    ? await findProjectWorktreePath(cwd, branch)
     : null;
 
   let rawDiff: string;

--- a/src/server/team-data.test.ts
+++ b/src/server/team-data.test.ts
@@ -23,6 +23,8 @@ mock.module('@anthropic-ai/sdk', () => ({
 // ---------------------------------------------------------------------------
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+import { createGitRepo, createTmpDir, removeTmpDir } from '~/cli/test-helpers';
 import { type Database, openDb } from '~/db/index';
 import {
   getProjectMessages,
@@ -32,6 +34,7 @@ import {
 import { getSession } from '~/db/sessions';
 import {
   parseMentions,
+  resolveProjectCwd,
   runConversationJudge,
   runConversationLoop,
 } from './team-data';
@@ -541,5 +544,55 @@ describe('runConversationLoop', () => {
     });
 
     expect(capturedOpts?.projectBranch).toBe('feature-xyz');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveProjectCwd
+// ---------------------------------------------------------------------------
+
+describe('resolveProjectCwd', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    await createGitRepo(tmpDir);
+  });
+
+  afterEach(async () => {
+    await removeTmpDir(tmpDir);
+  });
+
+  it('returns git root when no branch is given', async () => {
+    const result = await resolveProjectCwd(tmpDir, undefined);
+    expect(result).toBe(tmpDir);
+  });
+
+  it('returns the worktree path when the branch has a worktree', async () => {
+    const { execSync } = await import('node:child_process');
+    const { mkdir, realpath } = await import('node:fs/promises');
+    const worktreeDir = join(tmpDir, '.nightshift', 'worktrees', 'my-feature');
+    await mkdir(join(tmpDir, '.nightshift', 'worktrees'), { recursive: true });
+    execSync('git branch feature-branch', { cwd: tmpDir, stdio: 'pipe' });
+    execSync(`git worktree add "${worktreeDir}" feature-branch`, {
+      cwd: tmpDir,
+      stdio: 'pipe',
+    });
+
+    const result = await resolveProjectCwd(tmpDir, 'feature-branch');
+    // Normalize both paths to resolve macOS /var → /private/var symlink
+    expect(await realpath(result)).toBe(await realpath(worktreeDir));
+  });
+
+  it('falls back to git root when branch has no worktree', async () => {
+    const { execSync } = await import('node:child_process');
+    execSync('git checkout -b no-worktree-branch', {
+      cwd: tmpDir,
+      stdio: 'pipe',
+    });
+    execSync('git checkout -', { cwd: tmpDir, stdio: 'pipe' });
+
+    const result = await resolveProjectCwd(tmpDir, 'no-worktree-branch');
+    expect(result).toBe(tmpDir);
   });
 });

--- a/src/server/team-data.test.ts
+++ b/src/server/team-data.test.ts
@@ -324,6 +324,58 @@ describe('runConversationLoop', () => {
 
     expect(capturedOpts?.projectBranch).toBe('feature-xyz');
   });
+
+  it('passes worktreeDir to the agent when provided', async () => {
+    const projectId = 'proj-worktree';
+    // biome-ignore lint/suspicious/noExplicitAny: test capture
+    let capturedOpts: Record<string, any> | undefined;
+    // biome-ignore lint/suspicious/noExplicitAny: test capture
+    const runAgentFn = mock(async (opts: Record<string, any>) => {
+      capturedOpts = opts;
+      return '@user done';
+    });
+    insertMessage(db, 'test-team', 'user', 'hey @alice work here', projectId);
+
+    await runConversationLoop({
+      db,
+      teamId: 'test-team',
+      team,
+      cwd: '/repo-root',
+      teamMemberMeta,
+      projectId,
+      worktreeDir: '/repo-root/.nightshift/worktrees/my-feature',
+      runAgentFn,
+    });
+
+    expect(capturedOpts?.cwd).toBe('/repo-root');
+    expect(capturedOpts?.worktreeDir).toBe(
+      '/repo-root/.nightshift/worktrees/my-feature',
+    );
+  });
+
+  it('teamFolder is an absolute path based on cwd', async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: test capture
+    let capturedOpts: Record<string, any> | undefined;
+    // biome-ignore lint/suspicious/noExplicitAny: test capture
+    const runAgentFn = mock(async (opts: Record<string, any>) => {
+      capturedOpts = opts;
+      return '@user done';
+    });
+    insertMessage(db, 'test-team', 'user', 'any thoughts?');
+
+    await runConversationLoop({
+      db,
+      teamId: 'test-team',
+      team,
+      cwd: '/repo-root',
+      teamMemberMeta,
+      runAgentFn,
+    });
+
+    expect(capturedOpts?.teamFolder).toBe(
+      '/repo-root/.nightshift/teams/test-team',
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/team-data.ts
+++ b/src/server/team-data.ts
@@ -61,6 +61,7 @@ type RunAgentFn = (opts: {
   teamFolder?: string;
   projectBranch?: string;
   cwd: string;
+  worktreeDir?: string;
   existingSdkSessionId?: string;
   onStatus?: (status: 'idle' | 'working', statusText?: string) => void;
   onSessionId?: (sessionId: string) => void;
@@ -85,6 +86,7 @@ export async function runConversationLoop({
   teamId,
   team,
   cwd,
+  worktreeDir,
   teamMemberMeta,
   projectBranch,
   projectId,
@@ -93,7 +95,13 @@ export async function runConversationLoop({
   db: import('~/db/index').Database;
   teamId: string;
   team: TeamMeta;
+  /** Git root — used for reading nightshift config and as fallback agent cwd. */
   cwd: string;
+  /**
+   * Worktree directory for the project. When set, agents run here so they can
+   * edit files on the project branch. Nightshift config is still read from `cwd`.
+   */
+  worktreeDir?: string;
   teamMemberMeta: Array<{ name: string; description: string; isLead: boolean }>;
   projectBranch?: string;
   /** When set, sessions and messages are scoped to this project rather than the team. */
@@ -144,7 +152,8 @@ export async function runConversationLoop({
   const runAgentImpl = runAgentFn ?? defaultRunAgent;
 
   const allAgentNames = teamMemberMeta.map((m) => m.name);
-  const teamFolder = join('.nightshift', 'teams', team.name);
+  // Absolute path so agents can locate team files regardless of their working directory.
+  const teamFolder = join(cwd, '.nightshift', 'teams', team.name);
 
   while (true) {
     const recentMessages = getRecentMessages();
@@ -191,6 +200,7 @@ export async function runConversationLoop({
           teamFolder,
           projectBranch,
           cwd,
+          worktreeDir,
         });
         // Race against a timeout so a hung SDK stream can't lock the conversation
         const timeoutPromise = new Promise<never>((_, reject) =>
@@ -366,13 +376,14 @@ export const sendProjectMessage = createServerFn({ method: 'POST' })
       (p) => p.id === data.projectId,
     );
 
-    const projectCwd = await resolveProjectCwd(cwd, project?.branch);
+    const worktreeDir = await resolveProjectCwd(cwd, project?.branch);
 
     await runConversationLoop({
       db,
       teamId: data.teamId,
       team: team ?? { name: data.teamId, lead: leadName, members: [] },
-      cwd: projectCwd,
+      cwd,
+      worktreeDir: worktreeDir !== cwd ? worktreeDir : undefined,
       teamMemberMeta,
       projectBranch: project?.branch,
       projectId: data.projectId,

--- a/src/server/team-data.ts
+++ b/src/server/team-data.ts
@@ -464,11 +464,13 @@ export const sendProjectMessage = createServerFn({ method: 'POST' })
       (p) => p.id === data.projectId,
     );
 
+    const projectCwd = await resolveProjectCwd(cwd, project?.branch);
+
     await runConversationLoop({
       db,
       teamId: data.teamId,
       team: team ?? { name: data.teamId, lead: leadName, members: [] },
-      cwd,
+      cwd: projectCwd,
       teamMemberMeta,
       projectBranch: project?.branch,
       projectId: data.projectId,
@@ -508,15 +510,46 @@ export const getAgentSession = createServerFn({ method: 'GET' })
     };
   });
 
+/**
+ * Returns the worktree path for the project's branch if a worktree exists,
+ * otherwise falls back to the git root cwd.
+ * Exported for testing.
+ */
+export async function resolveProjectCwd(
+  cwd: string,
+  projectBranch: string | undefined,
+): Promise<string> {
+  if (!projectBranch) return cwd;
+  const { findProjectWorktreePath } = await import('./worktrees');
+  const worktreePath = await findProjectWorktreePath(cwd, projectBranch);
+  return worktreePath ?? cwd;
+}
+
 export const createNewProject = createServerFn({ method: 'POST' })
   .inputValidator((data: { teamId: string; name: string }) => data)
   .handler(async ({ data }) => {
-    const { insertProject } = await import('~/db/projects');
+    const { branchExists } = await import('~/db/projects');
+    const { join } = await import('node:path');
+    const { createProjectWithWorktree } = await import('./worktrees');
+
+    const cwd = await resolveCwd();
     const db = await getDb();
-    const branch =
+
+    const base =
       data.name
         .toLowerCase()
         .replace(/\s+/g, '-')
         .replace(/[^a-z0-9-]/g, '') || 'new-project';
-    return insertProject(db, data.name, data.teamId, branch);
+    const branch = branchExists(db, base)
+      ? `${base}-${Math.random().toString(16).slice(2, 6)}`
+      : base;
+    const worktreePath = join(cwd, '.nightshift', 'worktrees', branch);
+    return createProjectWithWorktree(
+      cwd,
+      worktreePath,
+      data.name,
+      data.teamId,
+      branch,
+      db,
+    );
   });

--- a/src/server/worktrees.test.ts
+++ b/src/server/worktrees.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { realpath } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { initNightshift } from '~/cli/commands/init';
+import { createGitRepo, createTmpDir, removeTmpDir } from '~/cli/test-helpers';
+import { openDb } from '~/db/index';
+import { getOpenProjectsByTeam } from '~/db/projects';
+import {
+  createProjectWithWorktree,
+  findProjectWorktreePath,
+} from './worktrees';
+
+describe('findProjectWorktreePath', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    await createGitRepo(tmpDir);
+  });
+
+  afterEach(async () => {
+    await removeTmpDir(tmpDir);
+  });
+
+  it('returns the worktree path when the branch has a worktree', async () => {
+    const worktreeDir = join(tmpDir, '.nightshift', 'worktrees', 'my-project');
+    await mkdir(join(tmpDir, '.nightshift', 'worktrees'), { recursive: true });
+    execSync('git branch feature-wt', { cwd: tmpDir, stdio: 'pipe' });
+    execSync(`git worktree add "${worktreeDir}" feature-wt`, {
+      cwd: tmpDir,
+      stdio: 'pipe',
+    });
+
+    const result = await findProjectWorktreePath(tmpDir, 'feature-wt');
+    // Normalize paths to resolve macOS /var → /private/var symlink
+    expect(result && (await realpath(result))).toBe(
+      await realpath(worktreeDir),
+    );
+  });
+
+  it('returns null when the branch has no worktree', async () => {
+    execSync('git checkout -b no-worktree', { cwd: tmpDir, stdio: 'pipe' });
+    execSync('git checkout -', { cwd: tmpDir, stdio: 'pipe' });
+
+    const result = await findProjectWorktreePath(tmpDir, 'no-worktree');
+    expect(result).toBeNull();
+  });
+
+  it('returns null for an unknown branch', async () => {
+    const result = await findProjectWorktreePath(tmpDir, 'nonexistent-branch');
+    expect(result).toBeNull();
+  });
+});
+
+describe('createProjectWithWorktree', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await createTmpDir();
+    await createGitRepo(tmpDir);
+    await initNightshift(tmpDir);
+  });
+
+  afterEach(async () => {
+    await removeTmpDir(tmpDir);
+  });
+
+  it('creates a git worktree at the specified path', async () => {
+    const db = openDb(':memory:');
+    const worktreePath = join(tmpDir, '.nightshift', 'worktrees', 'my-feature');
+    await createProjectWithWorktree(
+      tmpDir,
+      worktreePath,
+      'my-feature',
+      'team',
+      'my-feature',
+      db,
+    );
+    expect(existsSync(worktreePath)).toBe(true);
+    db.close();
+  });
+
+  it('inserts the project record into the DB', async () => {
+    const db = openDb(':memory:');
+    const worktreePath = join(tmpDir, '.nightshift', 'worktrees', 'my-feature');
+    await createProjectWithWorktree(
+      tmpDir,
+      worktreePath,
+      'my-feature',
+      'team',
+      'my-feature',
+      db,
+    );
+    const projects = getOpenProjectsByTeam(db, 'team');
+    expect(projects).toHaveLength(1);
+    expect(projects[0].name).toBe('my-feature');
+    expect(projects[0].branch).toBe('my-feature');
+    db.close();
+  });
+
+  it('returns the created project record', async () => {
+    const db = openDb(':memory:');
+    const worktreePath = join(tmpDir, '.nightshift', 'worktrees', 'feat');
+    const project = await createProjectWithWorktree(
+      tmpDir,
+      worktreePath,
+      'My Feature',
+      'team',
+      'feat',
+      db,
+    );
+    expect(project.name).toBe('My Feature');
+    expect(project.branch).toBe('feat');
+    expect(project.team_id).toBe('team');
+    db.close();
+  });
+
+  it('preserves original name in DB while using branch for the worktree', async () => {
+    const db = openDb(':memory:');
+    const branch = 'my-feature';
+    const worktreePath = join(tmpDir, '.nightshift', 'worktrees', branch);
+    const project = await createProjectWithWorktree(
+      tmpDir,
+      worktreePath,
+      'My Feature',
+      'team',
+      branch,
+      db,
+    );
+    expect(project.name).toBe('My Feature');
+    expect(project.branch).toBe('my-feature');
+    db.close();
+  });
+});

--- a/src/server/worktrees.ts
+++ b/src/server/worktrees.ts
@@ -1,0 +1,61 @@
+import type { Database } from '~/db/index';
+import type { Project } from '~/db/projects';
+
+/**
+ * Returns the filesystem path of the worktree that has `branch` checked out,
+ * or null if no worktree exists for that branch.
+ */
+export async function findProjectWorktreePath(
+  cwd: string,
+  branch: string,
+): Promise<string | null> {
+  const { execFileSync } = await import('node:child_process');
+  let output: string;
+  try {
+    output = execFileSync('git', ['worktree', 'list', '--porcelain'], {
+      cwd,
+      stdio: 'pipe',
+    }).toString();
+  } catch {
+    return null;
+  }
+  // Porcelain format: blank-line-separated blocks of:
+  //   worktree <path>
+  //   HEAD <sha>
+  //   branch refs/heads/<name>   (or "detached")
+  for (const block of output.split('\n\n')) {
+    const lines = block.split('\n');
+    const pathLine = lines.find((l) => l.startsWith('worktree '));
+    const branchLine = lines.find((l) => l.startsWith('branch '));
+    if (!pathLine || !branchLine) continue;
+    const worktreePath = pathLine.slice('worktree '.length).trim();
+    const worktreeBranch = branchLine
+      .slice('branch '.length)
+      .trim()
+      .replace(/^refs\/heads\//, '');
+    if (worktreeBranch === branch) return worktreePath;
+  }
+  return null;
+}
+
+/**
+ * Creates a git worktree at `worktreePath` on a new branch and inserts the
+ * project record in the database. Used by both the CLI and server so that
+ * project creation goes through a single code path.
+ */
+export async function createProjectWithWorktree(
+  cwd: string,
+  worktreePath: string,
+  name: string,
+  teamId: string,
+  branch: string,
+  db: Database,
+): Promise<Project> {
+  const { execFileSync } = await import('node:child_process');
+  const { insertProject } = await import('~/db/projects');
+  execFileSync('git', ['worktree', 'add', worktreePath, '-b', branch], {
+    cwd,
+    stdio: 'pipe',
+  });
+  return insertProject(db, name, teamId, branch);
+}


### PR DESCRIPTION
Fixes #42

## Summary

- **Missing worktree on UI project creation**: `createNewProject` was only inserting a DB record. It now calls the shared `createProjectWithWorktree` which runs `git worktree add` before inserting.
- **Agents running in git root**: `sendProjectMessage` was passing the git root as `cwd` to `runConversationLoop`. It now calls `resolveProjectCwd`, which uses `findProjectWorktreePath` to locate the project's worktree and passes that path instead.

## Architecture

New `src/server/worktrees.ts` is the shared home for worktree utilities:

- `findProjectWorktreePath(cwd, branch)` — asks git for the worktree path of a given branch; previously duplicated inside `artefacts.ts`
- `createProjectWithWorktree(cwd, worktreePath, name, teamId, branch, db)` — runs `git worktree add` and inserts the DB record; now used by both `ns project create` (CLI) and `createNewProject` (server), so both paths go through the same code

The CLI's `createProject` keeps its own validation layer (`assertValidName`, `assertInitialized`, `assertNotExists`) on top of the shared function. The server handler keeps its own name-sanitization (slug derivation) — these are intentionally different UX contracts, not bugs.

## Test plan

- `src/server/worktrees.test.ts` — new tests for `findProjectWorktreePath` and `createProjectWithWorktree`
- `src/server/team-data.test.ts` — new tests for `resolveProjectCwd`
- All existing CLI project tests continue to pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)